### PR TITLE
Fix setup_required in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'nltk': ['nltk'],
         'test': TEST_REQUIRES
     },
-    setup_requires=INSTALL_REQUIRES,
     platforms=['any'],
     keywords='pandas dataframe pipeline data',
     classifiers=[


### PR DESCRIPTION
In the setup.py there are the following lines:

`install_requires=INSTALL_REQUIRES,`
`setup_requires=INSTALL_REQUIRES,`

I think they should only be `install_requires` and not `setup_requires`. This causes an [issue](https://github.com/conda-forge/staged-recipes/pull/13085) where dependencies during conda packaging can't be met. Removal of the line fixes the problem.

Does that sound reasonable? Sorry for the earlier confusion on my part about sklearn :)