### PR TITLE
Docs/Improve documentation

### DIFF
--- a/pdpipe/basic_stages.py
+++ b/pdpipe/basic_stages.py
@@ -27,7 +27,7 @@ class ColDrop(ColumnsBasedPipelineStage):
     columns : single label, list-like or callable
         The label, or an iterable of labels, of columns to drop. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
+        labels from an input pandas.DataFrame (see `pdpipe.cq`).
     errors : {‘ignore’, ‘raise’}, default ‘raise’
         If ‘ignore’, suppress error and existing labels are dropped.
 
@@ -83,12 +83,12 @@ class ValDrop(ColumnsBasedPipelineStage):
         The label, or an iterable of labels, of columns to check for the given
         values. Alternatively, this parameter can be assigned a callable
         returning an iterable of labels from an input pandas.DataFrame. See
-        pdpipe.cq. If set to None, all columns are checked.
-    exclude_columns : object, iterable or callable, optional
+        `pdpipe.cq`. If set to None, all columns are checked.
+    exclude_columns : label, iterable or callable, optional
         The label, or an iterable of labels, of columns to exclude, given the
         `columns` parameter. Alternatively, this parameter can be assigned a
         callable returning a labels iterable from an input pandas.DataFrame.
-        See pdpipe.cq. Optional. By default no columns are excluded.
+        See `pdpipe.cq`. Optional. By default no columns are excluded.
 
     Example
     -------
@@ -143,12 +143,12 @@ class ValKeep(ColumnsBasedPipelineStage):
         The label, or an iterable of labels, of columns to check for the given
         values. Alternatively, this parameter can be assigned a callable
         returning an iterable of labels from an input pandas.DataFrame. See
-        pdpipe.cq. If set to None, all columns are checked.
-    exclude_columns : object, iterable or callable, optional
+        `pdpipe.cq`. If set to None, all columns are checked.
+    exclude_columns : single label, iterable or callable, optional
         The label, or an iterable of labels, of columns to exclude, given the
         `columns` parameter. Alternatively, this parameter can be assigned a
         callable returning a labels iterable from an input pandas.DataFrame.
-        See pdpipe.cq. Optional. By default no columns are excluded.
+        See `pdpipe.cq`. Optional. By default no columns are excluded.
 
     Example
     -------
@@ -190,7 +190,7 @@ class ColRename(PdPipelineStage):
 
     Parameters
     ----------
-    rename_mapper : dict-like or function
+    rename_mapper : dict-like or callable
         Maps old column names to new ones.
 
     Example
@@ -201,12 +201,21 @@ class ColRename(PdPipelineStage):
            len initial
         1    8       a
         2    5       b
+
+        >>> def renamer(lbl: str):
+        ...    if lbl.startswith('n'):
+        ...       return 'foo'
+        ...    return lbl
+        >>> pdp.ColRename(renamer).apply(df)
+           foo char
+        1    8    a
+        2    5    b
     """
 
     _DEF_COLDRENAME_EXC_MSG = ("ColRename stage failed because not all columns"
                                " {} were found in input dataframe.")
 
-    def __init__(self, rename_mapper, **kwargs):
+    def __init__(self, rename_mapper: Union[Dict,Callable], **kwargs):
         self._rename_mapper = rename_mapper
         try:
             columns_str = _list_str(list(rename_mapper.keys()))
@@ -360,7 +369,7 @@ class FreqDrop(PdPipelineStage):
                              " found in input dataframe.")
     _DEF_FREQDROP_DESC = "Drop values with frequency < {} in column {}."
 
-    def __init__(self, threshold, column, **kwargs):
+    def __init__(self, threshold: int, column: str, **kwargs):
         self._threshold = threshold
         self._column = column
         super_kwargs = {
@@ -437,7 +446,7 @@ class ColReorder(PdPipelineStage):
 
 
 class RowDrop(ColumnsBasedPipelineStage):
-    """A pipeline stage that drop rows by callable conditions.
+    """A pipeline stage that drops rows by callable conditions.
 
     Parameters
     ----------
@@ -454,20 +463,20 @@ class RowDrop(ColumnsBasedPipelineStage):
         satisfying at least one of the conditions are dropped. If set to 'xor',
         rows satisfying exactly one of the conditions will be dropped. Set to
         'any' by default.
-    columns : str or iterable, optional
+    columns : single label, iterable or callable, optional
         The label, or an iterable of labels, of columns. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq. If given,
+        labels from an input pandas.DataFrame. See `pdpipe.cq`. If given,
         input conditions will be applied to the sub-dataframe made up of
         these columns to determine which rows to drop. Ignored if `conditions`
         is provided with a dict object. If `conditions` is a list and this
         parameter is not provided, all columns are checked (unless
         `exclude_columns` is additionally provided)
-    exclude_columns : object, iterable or callable, optional
+    exclude_columns : single label, iterable or callable, optional
         The label, or an iterable of labels, of columns to exclude, given the
         `columns` parameter. Alternatively, this parameter can be assigned a
         callable returning a labels iterable from an input pandas.DataFrame.
-        See pdpipe.cq. Optional. By default no columns are excluded.
+        See `pdpipe.cq`. Optional. By default no columns are excluded.
 
     Example
     -------
@@ -568,7 +577,7 @@ class Schematize(PdPipelineStage):
     Parameters
     ----------
     columns: sequence of labels
-        The dataframe schema to enfore on input dataframes.
+        The dataframe schema to enforce on input dataframes.
 
     Example
     -------
@@ -621,7 +630,7 @@ class DropDuplicates(ColumnsBasedPipelineStage):
         The label, or an iterable of labels, of columns to exclude, given the
         `columns` parameter. Alternatively, this parameter can be assigned a
         callable returning a labels iterable from an input pandas.DataFrame.
-        See pdpipe.cq. Optional. By default no columns are excluded.
+        See `pdpipe.cq`. Optional. By default no columns are excluded.
 
     Examples
     --------
@@ -659,12 +668,12 @@ class ColumnDtypeEnforcer(PdPipelineStage):
         Use {col: dtype, …}, where col is a column label and dtype is a
         numpy.dtype or Python type to cast one or more of the DataFrame’s
         columns to column-specific types. Alternatively, you can provide
-        ColumnQualifier objects as keys. If at least one such key is present,
+        `ColumnQualifier` objects as keys. If at least one such key is present,
         the lbl-to-dtype dict is dynamically inferred each time the pipeline
-        stage is applied (note that ColumnQualifier objects are fittable by
+        stage is applied (note that `ColumnQualifier` objects are fittable by
         default, so to have column labels re-inferred after the first stage
-        application you'll have to set `fittable=False` for the ColumnQualifier
-        you use).
+        application you'll have to set `fittable=False` for the `ColumnQualifier`
+        you use, see `pdpipe.cq`).
     errors: {‘raise’, ‘ignore’}, default ‘raise’
         Control raising of exceptions on invalid data for provided dtype.
         - raise : allow exceptions to be raised
@@ -675,6 +684,11 @@ class ColumnDtypeEnforcer(PdPipelineStage):
         >>> import pandas as pd; import pdpipe as pdp;
         >>> df = pd.DataFrame([[8,'a'],[5,'b']], [1,2], ['num', 'initial'])
         >>> pdp.ColumnDtypeEnforcer({'num': float}).apply(df)
+           num initial
+        1  8.0       a
+        2  5.0       b
+
+        >>> pdp.ColumnDtypeEnforcer({pdp.cq.StartWith('n'): float}).apply(df)
            num initial
         1  8.0       a
         2  5.0       b
@@ -758,14 +772,13 @@ class ConditionValidator(PdPipelineStage):
     objects, and checks that all these callable return True - meaning all
     defined conditions hold - for input dataframes.
 
-    Naturally, pdpipe Condition objects from the pdpipe.cond module can be
-    used.
+    Naturally, pdpipe `Condition` objects from the `pdpipe.cond` module can be used.
 
     Parameters
     ----------
     conditions : callable or list-like of callable
         The conditions to check for input dataframes. Naturally, pdpipe
-        Condition objects from the pdpipe.cond module can be used.
+        `Condition` objects from the `pdpipe.cond` module can be used.
     reducer : callable, optional
         The callable that reduces the list of boolean result to a single
         result. By default the built-in `all` function is used, so all
@@ -784,7 +797,12 @@ class ConditionValidator(PdPipelineStage):
     -------
         >>> import pandas as pd; import pdpipe as pdp;
         >>> df = pd.DataFrame([[1,4],[4,None],[1,11]], [1,2,3], ['a','b'])
-        >>> pdp.ConditionValidator(pdp.cond.HasNoMissingValues())(df)
+        >>> pdp.ConditionValidator(lambda df: len(df.columns) == 5).apply(df)
+        Traceback (most recent call last):
+           ...
+        pdpipe.exceptions.FailedConditionError: ConditionValidator stage failed; some conditions did not hold for the input dataframe!
+        
+        >>> pdp.ConditionValidator(pdp.cond.HasNoMissingValues()).apply(df)
         Traceback (most recent call last):
            ...
         pdpipe.exceptions.FailedConditionError: ConditionValidator stage failed; some conditions did not hold for the input dataframe!

--- a/pdpipe/col_generation.py
+++ b/pdpipe/col_generation.py
@@ -1,4 +1,4 @@
-"""Basic pdpipe PdPipelineStages."""
+"""Column generation pdpipe PdPipelineStages."""
 
 import abc
 from typing import Union, Tuple, Optional, Dict, Callable
@@ -21,7 +21,7 @@ from .exceptions import PipelineApplicationError
 class Bin(PdPipelineStage):
     """A pipeline stage that adds a binned version of a column or columns.
 
-    If drop is set to True the new columns retain the names of the source
+    If drop is set to True, the new columns retain the names of the source
     columns; otherwise, the resulting column gain the suffix '_bin'
 
     Parameters
@@ -41,7 +41,7 @@ class Bin(PdPipelineStage):
     Example
     -------
         >>> import pandas as pd; import pdpipe as pdp;
-        >>> df = pd.DataFrame([[-3],[4],[5], [9]], [1,2,3, 4], ['speed'])
+        >>> df = pd.DataFrame([[-3],[4],[5],[9]], [1,2,3,4], ['speed'])
         >>> pdp.Bin({'speed': [5]}, drop=False).apply(df)
            speed speed_bin
         1     -3        <5
@@ -137,7 +137,7 @@ class OneHotEncode(ColumnsBasedPipelineStage):
 
     By default only k-1 dummies are created fo k categorical levels, as to
     avoid perfect multicollinearity between the dummy features (also called
-    the dummy variabletrap). This is done since features are usually one-hot
+    the dummy variable trap). This is done since features are usually one-hot
     encoded for use with linear models, which require this behaviour.
 
     Parameters
@@ -147,14 +147,14 @@ class OneHotEncode(ColumnsBasedPipelineStage):
         all the columns with object or category dtype will be converted, except
         those given in the exclude_columns parameter. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
     dummy_na : bool, default False
         Add a column to indicate NaNs, if False NaNs are ignored.
-    exclude_columns : str or list-like, default None
+    exclude_columns : single label, list-like or callable, default None
         Label or labels of columns to be excluded from encoding. If None then
         no column is excluded. Alternatively, this parameter can be assigned a
         callable returning an iterable of labels from an input
-        pandas.DataFrame. See pdpipe.cq. Optional.
+        pandas.DataFrame. See `pdpipe.cq`. Optional.
     drop_first : bool or single label, default True
         Whether to get k-1 dummies out of k categorical levels by removing the
         first level. If a non bool argument matching one of the categories is
@@ -286,10 +286,10 @@ class ColumnTransformer(ColumnsBasedPipelineStage):
 
     Parameters
     ----------
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq. If None is provided all
+        from an input pandas.DataFrame. See `pdpipe.cq`. If None is provided all
         input columns are transformed.
     result_columns : single label or list-like, default None
         Labels for the new columns resulting from the transformations. Must
@@ -301,17 +301,6 @@ class ColumnTransformer(ColumnsBasedPipelineStage):
         If set to True, source columns are dropped after being transformed.
     suffix : str, default '_transformed'
         The suffix transformed columns gain if no new column labels are given.
-
-    Example
-    -------
-        >>> import pandas as pd; import pdpipe as pdp;
-        >>> df = pd.DataFrame([[1], [3], [2]], ['UK', 'USSR', 'US'], ['Medal'])
-        >>> value_map = {1: 'Gold', 2: 'Silver', 3: 'Bronze'}
-        >>> pdp.MapColVals('Medal', value_map).apply(df)
-               Medal
-        UK      Gold
-        USSR  Bronze
-        US    Silver
     """
 
     def __init__(
@@ -382,7 +371,7 @@ class MapColVals(ColumnTransformer):
     columns : single label, list-like or callable
         Column labels in the DataFrame to be mapped. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq. If None is provided all
+        from an input pandas.DataFrame. See `pdpipe.cq`. If None is provided all
         input columns are mapped.
     value_map : dict, pandas.Series, callable, str or tuple
         The value-to-value map to use, mapping existing values to new one. If a
@@ -401,7 +390,7 @@ class MapColVals(ColumnTransformer):
         be of the same length as columns. If None, behavior depends on the
         drop parameter: If drop is True, then the label of the source column is
         used; otherwise, the label of the source column is used with the suffix
-        '_map'.
+        given ("_map" by default).
     drop : bool, default True
         If set to True, source columns are dropped after being mapped.
     suffix : str, default '_map'
@@ -417,6 +406,22 @@ class MapColVals(ColumnTransformer):
         UK      Gold
         USSR  Bronze
         US    Silver
+
+        >>> from datetime import timedelta;
+        >>> df = pd.DataFrame(
+        ...    data=[
+        ...       [timedelta(weeks=2)],
+        ...       [timedelta(weeks=4)],
+        ...       [timedelta(weeks=10)]
+        ...    ],
+        ...    index=['proposal', 'midterm', 'finals'],
+        ...    columns=['Due'],
+        ... )
+        >>> pdp.MapColVals('Due', ('total_seconds', {})).apply(df)
+                        Due
+        proposal  1209600.0
+        midterm	  2419200.0
+        finals	  6048000.0
     """
 
     def __init__(
@@ -474,7 +479,7 @@ class ApplyToRows(PdPipelineStage):
         The label of the new column resulting from the function application. If
         None, 'new_col' is used. Ignored if a DataFrame is generated by the
         function (i.e. each row generates a Series rather than a value), in
-        which case the laebl of each column in the resulting DataFrame is used.
+        which case the label of each column in the resulting DataFrame is used.
     follow_column : str, default None
         Resulting columns will be inserted after this column. If None, new
         columns are inserted at the end of the processed DataFrame.
@@ -482,7 +487,7 @@ class ApplyToRows(PdPipelineStage):
         A function description of the given function; e.g. 'normalizing revenue
         by company size'. A default description is used if None is given.
     prec : function, default None
-        A function taking a DataFrame, returning True if it this stage is
+        A function taking a DataFrame, returning True if this stage is
         applicable to the given DataFrame. If None is given, a function always
         returning True is used.
 
@@ -499,6 +504,7 @@ class ApplyToRows(PdPipelineStage):
         1      3         2143           6429
         2     10         1321          13210
         3      7         1255           8785
+
         >>> def halfer(row):
         ...     new = {'year/2': row['years']/2, 'rev/2': row['avg_revenue']/2}
         ...     return pd.Series(new)
@@ -579,13 +585,14 @@ class ApplyToRows(PdPipelineStage):
 
 class ApplyByCols(ColumnTransformer):
     """A pipeline stage applying an element-wise function to columns.
+    For applying series-wise function, see `AggByCols`.
 
     Parameters
     ----------
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     func : function
         The function to be applied to each element of the given columns.
     result_columns : str or list-like, default None
@@ -648,7 +655,7 @@ class ApplyByCols(ColumnTransformer):
 
 
 class ColByFrameFunc(PdPipelineStage):
-    """A pipeline stage adding a column by applying a dataframw-wide function.
+    """A pipeline stage adding a column by applying a dataframe-wide function.
 
     Note that assigning `column` with the label of an existing column and
     providing the same label to the `before_column` parameter will result in
@@ -741,13 +748,19 @@ class ColByFrameFunc(PdPipelineStage):
 
 class AggByCols(ColumnTransformer):
     """A pipeline stage applying a series-wise function to columns.
+    For applying element-wise function, see `ApplyByCols`.
 
     Parameters
     ----------
-    columns : str or list-like
-        Names of columns on which to apply the given function.
+    columns : single label, list-like or callable
+        Column labels in the DataFrame to be transformed. Alternatively, this
+        parameter can be assigned a callable returning an iterable of labels
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     func : function
-        The function to be applied to each of the given columns.
+        The function to be applied to each of the given columns. Must work when 
+        given a pandas.Series object and return either a Scaler or pandas.Series.
+        If a Scaler is returned, the result is broadcasted into a column of the 
+        original length.
     result_columns : str or list-like, default None
         The names of the new columns resulting from the mapping operation. Must
         be of the same length as columns. If None, behavior depends on the
@@ -768,12 +781,19 @@ class AggByCols(ColumnTransformer):
         >>> import pandas as pd; import pdpipe as pdp; import numpy as np;
         >>> data = [[3.2, "acd"], [7.2, "alk"], [12.1, "alk"]]
         >>> df = pd.DataFrame(data, [1,2,3], ["ph","lbl"])
-        >>> log_ph = pdp.ApplyByCols("ph", np.log)
+        >>> log_ph = pdp.AggByCols("ph", np.log)
         >>> log_ph(df)
                  ph  lbl
         1  1.163151  acd
         2  1.974081  alk
         3  2.493205  alk
+
+        >>> min_ph = pdp.AggByCols("ph", min, drop=False, suffix='_min')
+        >>> min_ph(df)
+             ph  ph_min  lbl
+        1   3.2     3.2  acd
+        2   7.2     3.2  alk
+        3  12.1     3.2  alk
     """
 
     def __init__(
@@ -813,17 +833,17 @@ class Log(ColumnsBasedPipelineStage):
 
     Parameters
     ----------
-    columns : str or list-like, default None
+    columns : single label, list-like or callable, default None
         Column names in the DataFrame to be encoded. If columns is None then
         all the columns with a numeric dtype will be transformed, except those
         given in the exclude_columns parameter. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
-    exclude_columns : str or list-like, default None
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
+    exclude_columns : single label, list-like or callable, default None
         Label or labels of columns to be excluded from encoding. If None then
         no column is excluded. Alternatively, this parameter can be assigned a
         callable returning an iterable of labels from an input
-        pandas.DataFrame. See pdpipe.cq. Optional.
+        pandas.DataFrame. See `pdpipe.cq`. Optional.
     drop : bool, default False
         If set to True, the source columns are dropped after being encoded,
         and the resulting encoded columns retain the names of the source

--- a/pdpipe/cond.py
+++ b/pdpipe/cond.py
@@ -1,21 +1,20 @@
 """Fittable conditions for pdpipe.
 
-In `pdipe`, pipeline stages have two optional constructor parameters that
+In `pdpipe`, pipeline stages have two optional constructor parameters that
 accept callables that are treated as conditions: `prec` and `skip`. Both assume
 input callables can accept a pandas.Dataframe object as input and return either
 True or False. `prec` - representing the stage's precondition - determines
 whether a stage *can* be applied to an input dataframe, while `skip` -
 representing the stage's skip condition - determines whether it *should* be
 applied. Accordingly, a stage throws a `FailedPreconditionError` if its
-precondition is not statisfied, while it is skipped if its skip-condition is
-not statisfied.
+precondition is not satisfied, while it is skipped if its skip-condition is satisfied.
 
 This module - `pdpipe.cond` - provides a way to easily generate `Condition`
 objects, which are callable, and can easily be made fittable - to have their
 result determined in fit time and preserved for future transforms - by
 assigning the constructor parameter `fittable=True`. This enables the creation
 of pipeline stages whose their effective inclusion in the pipeline is
-determinedonly  when `fit_transform` is called; for example, whether
+determined only  when `fit_transform` is called; for example, whether
 dimensionality reduction is required - once this decision is done in training
 time it should be maintained for all future transforms of data (in test and
 validation sets or in production).
@@ -130,7 +129,7 @@ class Condition(object):
         Returns
         -------
         bool
-            Either True of False.
+            Either True or False.
         """
         self._result = self._func(df)
         return self._result
@@ -160,7 +159,7 @@ class Condition(object):
         Returns
         -------
         bool
-            Either True of False.
+            Either True or False.
         """
         if not self._fittable:
             return self._func(df)
@@ -253,7 +252,7 @@ class Condition(object):
 
 
 class PerColumnCondition(Condition):
-    """Checks whether the columns of input dataframes statisfy a condition set.
+    """Checks whether the columns of input dataframes satisfy a condition set.
 
     Parameters
     ----------
@@ -262,7 +261,7 @@ class PerColumnCondition(Condition):
         must satisfy. Conditions are callables that accept a `pandas.Series`
         object and return a `bool` value.
     conditions_reduce : str, default 'all'
-        How condition statisfaction results are reduced per-column, in case of
+        How condition satisfaction results are reduced per-column, in case of
         multiple conditions. 'all' requires a column to satisfy all conditions,
         while 'any' requires at least one condition to be satisfied.
     columns_reduce : str, default 'all'
@@ -270,7 +269,7 @@ class PerColumnCondition(Condition):
         'all' requires all columns of input dataframes to satisfy the given
         condition (in the case of multiple conditions, behaviour is determined
         by the `condition_reduce` parameter), while 'any' requires at least one
-        column to statisfy it.
+        column to satisfy it.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
         Condition. See the documentation of Condition for details.
@@ -284,7 +283,7 @@ class PerColumnCondition(Condition):
         ...     conditions=lambda x: x.dtype == np.int64,
         ... )
         >>> cond
-        <pdpipe.Condition: Dataframes with all columns stasifying all \
+        <pdpipe.Condition: Dataframes with all columns satisfying all \
 conditions: anonymous condition>
         >>> cond(df)
         False
@@ -370,7 +369,7 @@ conditions: anonymous condition>
             cond_reduce=self._cond_reduce,
             col_reduce=self._col_reduce,
         )
-        doc_str = "Dataframes with {} columns stasifying {} conditions: {}"
+        doc_str = "Dataframes with {} columns satisfying {} conditions: {}"
         self._func_doc = doc_str.format(
             self._col_reduce_str, self._cond_reduce_str, self._conditions_str)
         _func.__doc__ = self._func_doc
@@ -420,7 +419,7 @@ class HasAllColumns(Condition):
                 lbl in df.columns
                 for lbl in self._labels
             ])
-        _func.__doc__ = f"Dataframes with colums {self._labels_str}"
+        _func.__doc__ = f"Dataframes with columns {self._labels_str}"
         kwargs['func'] = _func
         super().__init__(**kwargs)
 
@@ -438,7 +437,7 @@ class ColumnsFromList(PerColumnCondition):
     columns_reduce : str, default 'all'
         How condition satisfaction results are reduced among multiple columns.
         'all' requires all columns of input dataframes to satisfy the given
-        condition, while 'any' requires at least one column to statisfy it.
+        condition, while 'any' requires at least one column to satisfy it.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
         Condition. See the documentation of Condition for details.
@@ -450,7 +449,7 @@ class ColumnsFromList(PerColumnCondition):
         ...    [[8,'a',5],[5,'b',7]], [1,2], ['num', 'chr', 'nur'])
         >>> cond = pdp.cond.ColumnsFromList('num')
         >>> cond
-        <pdpipe.Condition: Dataframes with all columns stasifying all \
+        <pdpipe.Condition: Dataframes with all columns satisfying all \
 conditions: Series with labels in num>
         >>> cond(df)
         False
@@ -538,7 +537,8 @@ class HasNoColumn(Condition):
 
 
 class HasAtMostMissingValues(Condition):
-    """Checks whether input dataframes has no more than X missing values.
+    """Checks whether input dataframes has no more than X missing values
+    across all columns.
 
     Parameters
     ----------

--- a/pdpipe/core.py
+++ b/pdpipe/core.py
@@ -7,17 +7,17 @@
 ## Creating pipeline stages that operate on column subsets
 
 Many pipeline stages in pdpipe operate on a subset of columns, allowing the
-caller to deteremine this subset by either providing a fixed set of column
+caller to determine this subset by either providing a fixed set of column
 labels or by providing a callable that determines the column subset dynamically
 from input dataframes. The `pdpipe.cq` module addresses a unique but important
-use case of fittable column qualifier, which dynamically extract a column
+use case of fittable column qualifier, which is to dynamically extract a column
 subset on stage fit time, but keep it fixed for future transformations.
 
 As a general rule, every pipeline stage in pdpipe that supports the `columns`
 parameter should inherently support fittable column qualifier, and generally
 the correct interpretation of both single and multiple labels as arguments. To
 unify the implementation of such functionality, and ease of creation of new
-pipeline stages, such columns shoul be created by extending the
+pipeline stages, such columns should be created by extending the
 ColumnsBasedPipelineStage base class, found in this module (`pdpipe.core`).
 
 The main interface of sub-classes of this base class with it is through the
@@ -38,11 +38,11 @@ The main interface of sub-classes of this base class with it is through the
   providing `columns=cq.OfDtype(np.number),
   exclude_columns=cq.OfDtype(np.int64)`. However, exposing the
   `exclude_columns` parameter can allow for specific unique behaviours; for
-  example, if the `none_columns` parametet - which configures the behavior
+  example, if the `none_columns` parameter - which configures the behavior
   when `columns` is provided with `None` - is set with
   a `cq.OfDtypes('category')` column qualifier, which means that all
   categorical columns are selected when `columns=None`, then exposing
-  `exclude_columns` allows easy specification of the "all categorical
+  `exclude_columns` allows for easy specification of the "all categorical
   columns except X" by just giving a column qualifier capturing X to
   `exclude_columns`, instead of having to reconstruct the default column
   qualifier by hand and substract from it the one representing X.
@@ -80,8 +80,8 @@ stage you're creating is inherently fittable or not:
    transforming.
 
 Again, taking a look at the VERY concise implementation of simple columns-based
-stages, like ColDrop or ValDrop, will probably make things clearer, and you can
-use those implementations as a template for yours.
+stages, like ColDrop or ValDrop in `pdpipe.basic_stages`, will probably make
+things clearer, and you can use those implementations as a template for yours.
 """
 
 import sys
@@ -219,7 +219,7 @@ class PdPipelineStage(abc.ABC):
         If true, a pdpipe.FailedPreconditionError is raised when this
         stage is applied to a dataframe for which the precondition does
         not hold. Otherwise the stage is skipped. Additionally, if true, a
-        pdpipe.FailedPostconditionError is raised if an expected post-codnition
+        pdpipe.FailedPostconditionError is raised if an expected post-condition
         does not hold for an output dataframe (after pipeline application).
         Otherwise pipeline application continues uninterrupted.
     exmsg : str, default None
@@ -233,30 +233,30 @@ class PdPipelineStage(abc.ABC):
         This can be assigned a callable that returns boolean values for input
         dataframes, which will be used to determine whether input dataframes
         satisfy the preconditions for this pipeline stage (see the `exraise`
-        parameter for the behaviour of failed preconditions). See pdp.cond for
-        more information on specialised Condition objects.
+        parameter for the behaviour of failed preconditions). See `pdpipe.cond`
+        for more information on specialised Condition objects.
     post : callable, default None
         This can be assigned a callable that returns boolean values for input
         dataframes, which will be used to determine whether input dataframes
         satisfy the postconditions for this pipeline stage (see the `exraise`
-        parameter for the behaviour of failed postconditions). See pdp.cond for
-        more information on specialised Condition objects.
+        parameter for the behaviour of failed postconditions). See `pdpipe.cond`
+        for more information on specialised Condition objects.
     skip : callable, default None
         This can be assigned a callable that returns boolean values for input
         dataframes, which will be used to determine whether this stage should
         be skipped for input dataframes - if the callable returns True for an
-        input dataframe, this stage will be skipped. See pdp.cond for more
+        input dataframe, this stage will be skipped. See `pdpipe.cond` for more
         information on specialised Condition objects.
     name : str, default ''
         The name of this stage. Pipelines can be sliced by this name.
 
     Attributes
     ----------
-    fit_context : PdpApplicationContext
+    fit_context : `PdpApplicationContext`
         An application context object that is only re-initialized before
         `fit_transform` calls, and is locked after pipeline application. It is
         injected into the PipelineStage by the encapsulating pipeline object.
-    application_context : PdpApplicationContext
+    application_context : `PdpApplicationContext`
         An application context object that is re-initialized before every
         pipeline application (so, also during transform operations of fitted
         pipelines), and is locked after pipeline application.It is injected
@@ -539,15 +539,15 @@ class ColumnsBasedPipelineStage(PdPipelineStage):
 
     Parameters
     ---------
-    columns : object, iterable or callable
+    columns : single label, iterable or callable
         The label, or an iterable of labels, of columns to use. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
-    exclude_columns : object, iterable or callable, optional
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
+    exclude_columns : single label, iterable or callable, optional
         The label, or an iterable of labels, of columns to exclude, given the
         `columns` parameter. Alternatively, this parameter can be assigned a
         callable returning a labels iterable from an input pandas.DataFrame.
-        See pdpipe.cq. Optional. By default no columns are excluded.
+        See `pdpipe.cq`. Optional. By default no columns are excluded.
     desc_temp : str, optional
         If given, assumed to be a format string, and every appearance of {} in
         it is replaced with an appropriate string representation of the columns
@@ -693,12 +693,12 @@ class AdHocStage(PdPipelineStage):
     specific name is assumed or used) to supply the callable with the pandas
     DataFrame object to transform. The following additional keyword arguments
     are supplied if the are included in the callable's signature:
-    `verbose` - Passed on from pdpipe's `fit`, `fit_transform`
+    `verbose` - Passed on from PdPipelineStage's `fit`, `fit_transform`
     and `apply` methods.
+    
     `fit_context` and `application_context` - Provides fit-specific and
-    application-specific contexts, in the form of PdpApplicationContext
-    objects, usually available to pipeline stages using `self.fit_context` and
-    `self.application_context`.
+    application-specific contexts (see `PdpApplicationContext`) usually available 
+    to pipeline stages using `self.fit_context` and `self.application_context`.
 
     Parameters
     ----------
@@ -714,6 +714,19 @@ class AdHocStage(PdPipelineStage):
         A callable that returns a boolean value. Represent a a precondition
         used to determine whether this stage can be applied to a given
         dataframe. If None is given, set to a function always returning True.
+
+    Example
+    -------
+        >>> import pandas as pd; import pdpipe as pdp;
+        >>> df = pd.DataFrame([[1, 'a'], [2, 'b']], [1, 2], ['num', 'char'])
+        >>> drop_num = pdp.AdHocStage(
+        ...   transform=lambda df: df.drop(['num'], axis=1),
+        ...   prec=lambda df: 'num' in df.columns
+        ... )
+        >>> drop_num.apply(df)
+          char
+        1    a
+        2    b
     """
 
     def __init__(self, transform, fit_transform=None, prec=None, **kwargs):
@@ -761,7 +774,7 @@ class AdHocStage(PdPipelineStage):
 class PdPipeline(PdPipelineStage, collections.abc.Sequence):
     """A pipeline for processing pandas DataFrame objects.
 
-    transformer_getter is usefull to avoid applying pipeline stages that are
+    `transformer_getter` is useful to avoid applying pipeline stages that are
     aimed to filter out items in a big dataset to create a training set for a
     machine learning model, for example, but should not be applied on future
     individual items to be transformed by the fitted pipeline.
@@ -934,7 +947,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
         Returns
         -------
         pandas.DataFrame
-            The resulting dacaframe.
+            The resulting dataframe.
         """
         if time:
             return self.__timed_fit_transform(
@@ -1205,7 +1218,7 @@ def make_pdpipeline(*stages):
 
     Examples
     --------
-    import pdpipe as pdp
-    make_pdpipeline(pdp.ColDrop('a'), pdp.Bin('speed'))
+        >>> import pdpipe as pdp
+        >>> p = make_pdpipeline(pdp.ColDrop('count'), pdp.DropDuplicates())
     """
     return PdPipeline(stages=stages)

--- a/pdpipe/cq.py
+++ b/pdpipe/cq.py
@@ -20,7 +20,7 @@ that stage, and (2) lead to a change in schema, which might cause errors down
 the pipeline, especially if there's a fitted machine learning model down the
 pipeline.
 
-Of course, this might be the desired behaviour ― to tranform coloumns 'alec'
+Of course, this might be the desired behaviour ― to transform columns 'alec'
 and 'alex' on the first `apply` call and 'alec' and 'apoxy' in transform time ―
 but usually this is not the case. In fact, in common machine learning
 scenarios ― whether it is fitting pre-processing parameters on the train set
@@ -34,7 +34,7 @@ explicitly fails if either once of the two columns, 'alec' and 'alex', is
 missing. This kind of behaviour is the only way to ensure preservation of both
 form and semantics of input vectors to our models down the pipeline.
 
-To enable this more sophicticated behaviour this module - `pdpipe.cq` - exposes
+To enable this more sophisticated behaviour, this module - `pdpipe.cq` - exposes
 a way to easily generate `ColumnQualifier` objects, which are callables that do
 exactly what was described above: Apply some criteria to determine a set of
 input columns when a pipeline is being fitted, but fixing it afterwards, on
@@ -43,7 +43,7 @@ future calls.
 Practically, this objects all expose `fit`, `transform` and `fit_transform`
 methods, and while the first time they are called the `fit_transform` method is
 called, future calls will actually call the `transform` method. Also, since
-they already expose this more poweful API, pipeline stages use it to enable
+they already expose this more powerful API, pipeline stages use it to enable
 an even more powerful (and quite frankly, expected) behavior: When a pipeline's
 `fit_transfrom` or `fit` methods are called, it calls the `fit_transform`
 method of the column qualifier it uses, so the qualifier itself is refitted
@@ -197,10 +197,10 @@ class ColumnQualifier(object):
     def transform(self, df):
         """Applies and returns the labels of the qualifying columns.
 
-        Is this ColumnQualifier is fittable, it will return the list of column
+        If this ColumnQualifier is fittable, it will return the list of column
         labels that was determined when fitted (or the subset of it that can
-        be found in the input datarame), if it's fitted, and throw an exception
-        if it is not.
+        be found in the input dataframe). It will throw an exception if it 
+        is not.
 
         Parameters
         ----------
@@ -381,13 +381,13 @@ def is_fittable_column_qualifier(obj):
 
 
 class AllColumns(ColumnQualifier):
-    """Selectes all columns in input dataframes.
+    """Selects all columns in input dataframes.
 
     Parameters
     ----------
     **kwargs
         Accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -432,7 +432,7 @@ class ByColumnCondition(ColumnQualifier):
     Parameters
     ----------
     cond : callable
-        A callaable that given an input pandas.Series object returns a boolean
+        A callable that given an input pandas.Series object returns a boolean
         value.
     safe : bool, default False
         If set to True, every call to given condition `cond` is is wrapped in
@@ -441,7 +441,7 @@ class ByColumnCondition(ColumnQualifier):
         assume a specific datatype for the checked column.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -484,7 +484,7 @@ class ByColumnCondition(ColumnQualifier):
 
 
 class ByLabels(ColumnQualifier):
-    """Selectes all columns with the given label or labels.
+    """Selects all columns with the given label or labels.
 
     Parameters
     ----------
@@ -492,7 +492,7 @@ class ByLabels(ColumnQualifier):
         Column labels which qualify.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -544,7 +544,7 @@ def columns_to_qualifier(columns):
     columns : single label, list-like or callable
         The label, or an iterable of labels, of columns. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
 
     Returns
     -------
@@ -577,7 +577,7 @@ class StartWith(ColumnQualifier):
         The prefix which qualifies columns.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -633,7 +633,7 @@ class OfDtypes(ColumnQualifier):
         to the `include` parameter of pandas.DataFrame.select_dtypes().
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -684,7 +684,7 @@ class WithAtMostMissingValues(ColumnQualifier):
         qualify.
     **kwargs
         Additionaly accepts all keyword arguments of the constructor of
-        ColumnQualifier. See the documentation of ColumnQualifier for details.
+        ColumnQualifier. See the documentation of `ColumnQualifier` for details.
 
     Example
     -------
@@ -728,7 +728,7 @@ class WithoutMissingValues(WithAtMostMissingValues):
     ----------
     **kwargs
         Accepts all keyword arguments of the constructor of ColumnQualifier.
-        See the documentation of ColumnQualifier for details.
+        See the documentation of `ColumnQualifier` for details.
 
     Example
     -------

--- a/pdpipe/documentation.md
+++ b/pdpipe/documentation.md
@@ -8,7 +8,7 @@ Features
 * Chaining pipeline stages constructor calls for easy, one-liners pipelines.
 * Pipeline arithmetics.
 * Easier handling of mixed data (numeric, categorical and others).
-* [Fully tested on Linux, macOS and Windows systems](https://travis-ci.org/pdpipe/pdpipe>).
+* [Fully tested on Linux, macOS and Windows systems](https://travis-ci.org/pdpipe/pdpipe).
 * Compatible with Python 3.5+.
 * Pure Python.
 
@@ -16,7 +16,7 @@ Features
 Design Decisions
 ----------------
 
-* **Extra infromative naming:** Meant to make pipelines very readable, understanding their entire flow by pipeline stages names; e.g. ColDrop vs. ValDrop instead of an all-encompassing Drop stage emulating the `pandas.DataFrame.drop` method.
+* **Extra informative naming:** Meant to make pipelines very readable, understanding their entire flow by pipeline stages names; e.g. ColDrop vs. ValDrop instead of an all-encompassing Drop stage emulating the `pandas.DataFrame.drop` method.
 * **Data science-oriented naming** (rather than statistics).
 * **A functional approach:** Pipelines never change input DataFrames. Nothing is done "in place".
 * **Opinionated operations:** Help novices avoid mistake by default appliance of good practices; e.g., one-hot-encoding (creating dummy variables) a column will drop one of the resulting columns by default, to avoid [the dummy variable trap](http://www.algosome.com/articles/dummy-variable-trap-regression.html) (perfect [multicollinearity](https://en.wikipedia.org/wiki/Multicollinearity)).
@@ -129,7 +129,7 @@ Additionally, the  method can be used to give stages as positional arguments.
 
 ### Printing Pipelines
 
-A pipeline structre can be clearly displayed by printing the object:
+A pipeline structure can be clearly displayed by printing the object:
 
 ```python
   >>> drop_name = pdp.ColDrop("Name")
@@ -213,13 +213,13 @@ Additionally, passing ``verbose=True`` to a pipeline apply call will apply all p
   res_df = pipeline.apply(df, verbose=True)
 ```
 
-Finally, `fit`, `transform` and `fit_transform` all call the corresponding pipeline stage methods of all stages composing the pipeline
+Finally, `fit`, `transform` and `fit_transform` all call the corresponding pipeline stage methods of all stages composing the pipeline.
 
 
 Column Qualifiers
 -----------------
 
-All `pdpipe` pipeline stages that posses the `columns` parameter can accept callables - instead of lists of labels - as valid arguments to that parameter. These callables are assumed to be column qualifiers - functions that can be applied to an input dataframe to extract the list of labels to operate on in run time.
+All `pdpipe` pipeline stages that possess the `columns` parameter can accept callables - instead of lists of labels - as valid arguments to that parameter. These callables are assumed to be column qualifiers - functions that can be applied to an input dataframe to extract the list of labels to operate on in run time.
 
 The module `pdpipe.cq` provides a powerful class - `ColumnQualifier` - implementing this idea with various enhancements, like the ability to fit a list of labels in fit time to be retained for future transforms and support for various boolean operators between column qualifiers.
 
@@ -237,6 +237,8 @@ All built-in stages are thoroughly documented, including examples; if you find a
 Basic Stages
 ------------
 
+Refer to submodule `pdpipe.basic_stages`
+
 * AdHocStage - Define custom pipeline stages on the fly.
 * ColDrop - Drop columns by name.
 * ValDrop - Drop rows by by their value in specific or all columns.
@@ -252,6 +254,8 @@ Basic Stages
 Column Generation
 -----------------
 
+Refer to submodule `pdpipe.col_generation`
+
 * Bin - Convert a continuous valued column to categoric data using binning.
 * OneHotEncode - Convert a categorical column to the several binary columns corresponding to it.
 * MapColVals - Replace column values by a map.
@@ -264,6 +268,8 @@ Column Generation
 Text Stages
 -----------
 
+Refer to submodule `pdpipe.text_stages`
+
 * RegexReplace - Replace regex occurences in columns of strings.
 * DropTokensByLength - Drop tokens in token lists by token length.
 * DropTokensByList - Drop every occurence of a given set of string tokens in token lists.
@@ -271,12 +277,16 @@ Text Stages
 Scikit-learn-dependent Stages
 -----------------------------
 
+Refer to submodule `pdpipe.sklearn_stages`
+
 * Encode - Encode a categorical column to corresponding number values.
 * Scale - Scale data with any of the sklearn scalers.
 * TfidfVectorizeTokenLists - Transform a column of token lists into the correponding set of tfidf vector columns.
 
 nltk-dependent Stages
 ---------------------
+
+Refer to submodule `pdpipe.nltk_stages`
 
 * TokenizeWords - Tokenize a sentence into a list of tokens by whitespaces.
 * UntokenizeWords - Joins token lists into whitespace-seperated strings.
@@ -291,7 +301,7 @@ Creating additional stages
 Extending PdPipelineStage
 -------------------------
 
-To use other stages than the built-in ones (see [Types of Pipeline Stages](#types-of-pipeline-stages) you can extend the  class. The constructor must pass the `PdPipelineStage` constructor the `exmsg`, `appmsg` and `desc` keyword arguments to set the exception message, application message and description for the pipeline stage, respectively. Additionally, the `_prec` and `_transform` abstract methods must be implemented to define the precondition and the effect of the new pipeline stage, respectively.
+To use other stages than the built-in ones (see [Types of Pipeline Stages](#types-of-pipeline-stages)) you can extend the  class. The constructor must pass the `PdPipelineStage` constructor the `exmsg`, `appmsg` and `desc` keyword arguments to set the exception message, application message and description for the pipeline stage, respectively. Additionally, the `_prec` and `_transform` abstract methods must be implemented to define the precondition and the effect of the new pipeline stage, respectively.
 
 Fittable custom pipeline stages should implement, additionally to the  method, the `_fit_transform` method, which should both fit pipeline stage by the input dataframe and transform transform the dataframe, while also setting `self.is_fitted = True`.
 

--- a/pdpipe/nltk_stages.py
+++ b/pdpipe/nltk_stages.py
@@ -27,7 +27,7 @@ from pdpipe.shared import (
 
 
 class TokenizeText(MapColVals):
-    """A pipeline stage that tokenize a text column into token lists.
+    """A pipeline stage that tokenizes a text column into token lists.
 
     Note: The nltk package must be installed for this pipeline stage to work.
 
@@ -36,7 +36,7 @@ class TokenizeText(MapColVals):
     columns : single label, list-like of callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     drop : bool, default True
         If set to True, the source columns are dropped after being tokenized,
         and the resulting tokenized columns retain the names of the source
@@ -92,7 +92,7 @@ class TokenizeText(MapColVals):
 
 
 class UntokenizeText(MapColVals):
-    """A pipeline stage that joins token lists to whitespace-seperated strings.
+    """A pipeline stage that joins token lists to whitespace-separated strings.
 
     Target columns must be series of token lists; i.e. every cell in the series
     is an iterable of string tokens.
@@ -104,7 +104,7 @@ class UntokenizeText(MapColVals):
     columns : single label, list-like of callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     drop : bool, default True
         If set to True, the source columns are dropped after being untokenized,
         and the resulting columns retain the names of the source columns.
@@ -121,7 +121,7 @@ class UntokenizeText(MapColVals):
         1   3.2  Shake and bake!
     """
 
-    _DEF_UNTOKENIZE_EXC_MSG = ("Unokenize stage failed because not all columns"
+    _DEF_UNTOKENIZE_EXC_MSG = ("Untokenize stage failed because not all columns"
                                " {} are present in input dataframe and are of"
                                " dtype object.")
 
@@ -159,15 +159,15 @@ class RemoveStopwords(MapColVals):
 
     Parameters
     ----------
-    langugae : str or array-like
+    language : str or array-like
         If a string is given, interpreted as the language of the stopwords, and
         should then be one of the languages supported by the NLTK Stopwords
         Corpus. If a list is given, it is assumed to be the list of stopwords
         to remove.
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     drop : bool, default True
         If set to True, the source columns are dropped after stopword removal,
         and the resulting columns retain the names of the source columns.
@@ -254,10 +254,10 @@ class SnowballStem(MapColVals):
     stemmer_name : str
         The name of the Snowball stemmer to use. Should be one of the Snowball
         stemmers implemented by nltk. E.g. 'EnglishStemmer'.
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     drop : bool, default True
         If set to True, the source columns are dropped after stemming, and the
         resulting columns retain the names of the source columns. Otherwise,
@@ -395,10 +395,10 @@ class DropRareTokens(ColumnsBasedPipelineStage):
 
     Parameters
     ----------
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame to be transformed. Alternatively, this
         parameter can be assigned a callable returning an iterable of labels
-        from an input pandas.DataFrame. See pdpipe.cq.
+        from an input pandas.DataFrame. See `pdpipe.cq`.
     threshold : int
         The rarity threshold to use. Only tokens appearing more than this
         number of times in a column will remain in token lists in that column.

--- a/pdpipe/skintegrate.py
+++ b/pdpipe/skintegrate.py
@@ -1,4 +1,17 @@
-"""Classes for sklearn integration."""
+"""Classes for sklearn integration.
+
+Despite similar names, there is a difference between pdpipe PdPipeline and 
+sklearn.pipeline.Pipeline. PdPipeline can only chain transformers while scikit-learn 
+Pipeline objects can further include the final estimator to provide additional 
+methods such as `predict` and `predict_proba`.
+
+This means that by itself, pdpipe PdPipeline does not integrate well with some
+of scikit-learn utility classes such as sklearn.model_selection.GridSearchCV compared
+to sklearn.pipeline.Pipeline.
+
+This module resolves such integration issues. Refer to the notebooks folder of 
+the pdpipe repository for complete examples.
+"""
 
 from typing import Callable
 from functools import update_wrapper
@@ -106,6 +119,26 @@ class PdPipelineAndSklearnEstimator(BaseEstimator):
         The preprocssing pipeline to connect.
     model : sklearn.base.BaseEstimator
         The model to connect to the pipeline.
+
+    Example
+    ----------
+        >>> import pandas as pd; import pdpipe as pdp;
+        >>> from pdpipe.skintegrate import PdPipelineAndSklearnEstimator;
+        >>> from sklearn.linear_model import LogisticRegression;
+        >>> DF2 = pd.DataFrame(
+        ...    data=[['-1',0], ['-1',0], ['1',1], ['1',1]],
+        ...    index=[1, 2, 3, 4],
+        ...    columns=['feature1', 'target']
+        ... )
+        >>> all_x = DF2[['feature1']]
+        >>> all_y = DF2['target']
+        >>> mp = PdPipelineAndSklearnEstimator(
+        ...    pipeline=pdp.ColumnDtypeEnforcer({'feature1': int}),
+        ...    estimator=LogisticRegression()
+        ... )
+        >>> mp.fit(all_x, all_y)
+        <PdPipeline -> LogisticRegression>
+        >>> res = mp.predict(all_x)
     """
 
     def __init__(
@@ -196,6 +229,7 @@ class PdPipelineAndSklearnEstimator(BaseEstimator):
         """Call predict_proba on the estimator with the best found parameters.
         Only available if ``refit=True`` and the underlying estimator supports
         ``predict_proba``.
+        
         Parameters
         ----------
         X : indexable, length n_samples
@@ -218,6 +252,7 @@ class PdPipelineAndSklearnEstimator(BaseEstimator):
         """Call predict_log_proba on the estimator with the best found parameters.
         Only available if ``refit=True`` and the underlying estimator supports
         ``predict_log_proba``.
+        
         Parameters
         ----------
         X : indexable, length n_samples
@@ -240,6 +275,7 @@ class PdPipelineAndSklearnEstimator(BaseEstimator):
         """Call decision_function on the estimator with the best found parameters.
         Only available if ``refit=True`` and the underlying estimator supports
         ``decision_function``.
+        
         Parameters
         ----------
         X : indexable, length n_samples
@@ -299,7 +335,10 @@ def pdpipe_scorer_from_sklearn_scorer(scorer: Callable) -> Callable:
     model-evaluation tools using cross-validation (such as
     model_selection.cross_val_score and model_selection.GridSearchCV), when
     searching over the hyperparameter space of a PdPipelineAndSklearnEstimator
-    object
+    object.
+
+    See the pipeline_and_model_with_test_test.ipynb notebook in the notebooks 
+    folder of the pdpipe repository for a complete example.
 
     Parameters
     ----------

--- a/pdpipe/sklearn_stages.py
+++ b/pdpipe/sklearn_stages.py
@@ -21,7 +21,7 @@ from sklearn.feature_extraction.text import (
 from pdpipe.core import PdPipelineStage, ColumnsBasedPipelineStage
 from pdpipe.util import (
     out_of_place_col_insert,
-    per_column_valus_sklearn_transform,
+    per_column_values_sklearn_transform,
 )
 from pdpipe.cq import OfDtypes
 from pdpipe.shared import (
@@ -46,15 +46,22 @@ class Encode(ColumnsBasedPipelineStage):
         all the columns with object or category dtype will be converted, except
         those given in the exclude_columns parameter. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
-    exclude_columns : str or list-like, default None
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
+    exclude_columns : single label, list-like or callable, default None
         Label or labels of columns to be excluded from encoding. If None then
         no column is excluded. Alternatively, this parameter can be assigned a
-        callable returning an iterable of labels from an input
+        callable returning an iterable of labels from an input pandas.DataFrame.
+        See `pdpipe.cq`.
     drop : bool, default True
         If set to True, the source columns are dropped after being encoded,
         and the resulting encoded columns retain the names of the source
         columns. Otherwise, encoded columns gain the suffix '_enc'.
+    
+    Attributes
+    ----------
+    encoders : dict
+        A dictionary mapping each encoded column name to the corresponding 
+        sklearn.preprocessing.LabelEncoder object. Empty object if not fitted.
 
     Example
     -------
@@ -141,17 +148,17 @@ class Scale(ColumnsBasedPipelineStage):
     scaler : str
         The type of scaler to use to scale the data. One of 'StandardScaler',
         'MinMaxScaler', 'MaxAbsScaler', 'RobustScaler', 'QuantileTransformer'
-        and 'Normalizer'.
+        and 'Normalizer'. Refer to scikit-learn's documentation for usage.
     columns : single label, list-like or callable, default None
-        Column labels in the DataFrame to be scale. If columns is None then
+        Column labels in the DataFrame to be scaled. If columns is None then
         all columns of numeric dtype will be scaled, except those given in the
         exclude_columns parameter. Alternatively, this parameter can be
         assigned a callable returning an iterable of labels from an input
-        pandas.DataFrame. See pdpipe.cq.
-    exclude_columns : str or list-like, optional
+        pandas.DataFrame. See `pdpipe.cq`.
+    exclude_columns : single label, list-like or callable, default None
         Label or labels of columns to be excluded from encoding. Alternatively,
         this parameter can be assigned a callable returning an iterable of
-        labels from an input pandas.DataFrame. See pdpipe.cq.
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
     joint : bool, default False
         If set to True, all scaled columns will be scaled as a single value
         set (meaning, only the single largest value among all input columns
@@ -214,7 +221,7 @@ class Scale(ColumnsBasedPipelineStage):
         try:
             if self.joint:
                 self._scaler.fit(np.array([inter_df.values.flatten()]).T)
-                inter_df = per_column_valus_sklearn_transform(
+                inter_df = per_column_values_sklearn_transform(
                     df=inter_df,
                     transform=self._scaler.transform
                 )
@@ -245,7 +252,7 @@ class Scale(ColumnsBasedPipelineStage):
         inter_df = df[self._columns_to_scale]
         try:
             if self.joint:
-                inter_df = per_column_valus_sklearn_transform(
+                inter_df = per_column_values_sklearn_transform(
                     df=inter_df,
                     transform=self._scaler.transform
                 )
@@ -277,10 +284,10 @@ class TfidfVectorizeTokenLists(PdPipelineStage):
 
     The resulting columns are concatenated to the end of the dataframe.
 
-    All valid sklearn.TfidfVectorizer keyword arguemnts can be provided as
-    keyword arguments to the constructor, except 'input' and 'analyzer', which
-    will be ignored. As usual, all valid PdPipelineStage constructor parameters
-    can also be provided as keyword arguments.
+    All valid sklearn.feature_extraction.text.TfidfVectorizer keyword arguments 
+    can be provided as keyword arguments to the constructor, except 'input' and 
+    'analyzer', which will be ignored. As usual, all valid PdPipelineStage 
+    constructor parameters can also be provided as keyword arguments.
 
     Parameters
     ----------

--- a/pdpipe/text_stages.py
+++ b/pdpipe/text_stages.py
@@ -12,27 +12,28 @@ class RegexReplace(ApplyByCols):
 
     Parameters
     ----------
-    columns : single label, list-like of callable
+    columns : single label, list-like or callable
         Column labels in the DataFrame which regex replacement be applied to.
         Alternatively, this parameter can be assigned a callable returning an
-        iterable of labels from an input pandas.DataFrame. See pdpipe.cq.
+        iterable of labels from an input pandas.DataFrame. See `pdpipe.cq`.
     pattern : str
         The regex whose occurences will be replaced.
     replace : str
         The replacement string to use. This is equivalent to repl in re.sub.
     flags : int, default 0
+        Regex flags that are compatible with Python's `re` module.
     result_columns : label or list-like of labels, default None
         The labels of the new columns resulting from the mapping operation.
         Must be of the same length as columns. If None, behavior depends on the
         drop parameter: If drop is True, the label of the source column is
-        used; otherwise, the label of the source column is caster to a string
+        used; otherwise, the label of the source column is casted to a string
         and concatenated with the suffix '_reg'.
     drop : bool, default True
         If set to True, source columns are dropped after being transformed.
 
     Example
     -------
-        >>> import pandas as pd; import pdpipe as pdp;
+        >>> import pandas as pd; import pdpipe as pdp; import re;
         >>> data = [[4, "more than 12"], [5, "with 5 more"]]
         >>> df = pd.DataFrame(data, [1,2], ["age","text"])
         >>> clean_num = pdp.RegexReplace('text', r'\\b[0-9]+\\b', "NUM")
@@ -40,6 +41,17 @@ class RegexReplace(ApplyByCols):
            age           text
         1    4  more than NUM
         2    5  with NUM more
+
+        >>> data = [["Mr. John", 18], ["MR. Bob", 25]]
+        >>> df = pd.DataFrame(data, [1,2], ["name","age"])
+        >>> match_men = r'^mr.*'
+        >>> censor_men = pdp.RegexReplace(
+        ...    'name', match_men, "x", flags=re.IGNORECASE
+        ... )
+        >>> censor_men(df)
+          name  age
+        1    x   18
+        2    x   25
     """  # noqa: W605
 
     class RegexReplacer(object):
@@ -93,8 +105,10 @@ class DropTokensByLength(ApplyByCols):
 
     Parameters
     ----------
-    columns : str or list-like
+    columns : single label, list-like or callable
         Names of token list columns on which to apply token filtering.
+        Alternatively, this parameter can be assigned a callable returning an 
+        iterable of labels from an input pandas.DataFrame. See `pdpipe.cq`.
     min_len : int
         The minimum length of tokens to keep. Tokens of shorter length are
         removed from all token lists.
@@ -173,8 +187,10 @@ class DropTokensByList(ApplyByCols):
 
     Parameters
     ----------
-    columns : str or list-like
-        Names of token list columns on which to apply token filtering.
+    columns : single label, list-like or callable
+        Names of token list columns on which to apply token filtering. 
+        Alternatively, this parameter can be assigned a callable returning an 
+        iterable of labels from an input pandas.DataFrame. See `pdpipe.cq`.
     bad_tokens : list of str
         The list of string tokens to remove from all token lists.
     result_columns : str or list-like, default None

--- a/pdpipe/types.py
+++ b/pdpipe/types.py
@@ -1,7 +1,7 @@
 """Custom types for pdpipe."""
 
-from typing import Union, List
+from typing import Union, List, Callable
 
 
-ColumnsParamType = Union[object, List[object], callable]
+ColumnsParamType = Union[object, List[object], Callable]
 ColumnLabelsType = Union[object, List[object]]

--- a/pdpipe/util.py
+++ b/pdpipe/util.py
@@ -74,7 +74,7 @@ def get_numeric_column_names(df):
     return num_cols
 
 
-def per_column_valus_sklearn_transform(df: pd.DataFrame, transform: callable):
+def per_column_values_sklearn_transform(df: pd.DataFrame, transform: callable):
     """Applies a 2d-array sklearn transform to 1d values arrays of a dataframe.
 
     Parameters

--- a/pdpipe/wrappers.py
+++ b/pdpipe/wrappers.py
@@ -1,4 +1,4 @@
-"""Wrapper-kind pdpipe pipline stages."""
+"""Wrapper-kind pdpipe pipeline stages."""
 
 
 from pdpipe.core import PdPipelineStage
@@ -6,6 +6,9 @@ from pdpipe.core import PdPipelineStage
 
 class FitOnly(PdPipelineStage):
     """A wrapper that applies a stage to input data only when fitting.
+
+    In other words, the input data is not transformed if the stage has
+    already been fitted once.
 
     Parameters
     ----------

--- a/tests/basic_stages/test_col_dtype_enforcer.py
+++ b/tests/basic_stages/test_col_dtype_enforcer.py
@@ -25,3 +25,7 @@ def test_dtype_enf_col_qualifier():
     assert res['num1'].dtype == float
     assert res['num2'].dtype == float
     assert res['rank'].dtype == bool
+
+    # Only col_qualifier as key, used as documentation example
+    res = ColumnDtypeEnforcer({cq.StartWith('n'): float}).apply(DF)
+    assert res['num'].dtype == float

--- a/tests/basic_stages/test_condition_validator.py
+++ b/tests/basic_stages/test_condition_validator.py
@@ -63,6 +63,10 @@ def test_condition_validator_lambda_fail():
     with pytest.raises(FailedConditionError):
         stage(DF1, verbose=True)
 
+    # Used as documentation example
+    with pytest.raises(FailedConditionError):
+        ConditionValidator(lambda df: len(df.columns) == 5).apply(DF1)
+
 
 def test_condition_validator_custom_func():
     def _foo(df: pd.DataFrame) -> bool:

--- a/tests/basic_stages/test_row_drop.py
+++ b/tests/basic_stages/test_row_drop.py
@@ -85,7 +85,7 @@ def test_row_drop_all_reducer():
     assert 3 in res_df.index
 
 
-def test_row_droo_bad_columns():
+def test_row_drop_bad_columns():
     """Testing the ColDrop pipeline stage."""
     with pytest.raises(FailedPreconditionError):
         RowDrop([lambda x: x < 2], columns=['d']).apply(DF1)

--- a/tests/col_generation/test_aggbycols.py
+++ b/tests/col_generation/test_aggbycols.py
@@ -21,22 +21,33 @@ def ph_df():
     )
 
 
-def test_aggbycols():
+def test_aggbycols_func_series():
     """Testing AggByCols pipeline stages."""
     df = ph_df()
-    round_ph = AggByCols("ph", np.log)
-    res_df = round_ph(df)
+    log_ph = AggByCols("ph", np.log)
+    res_df = log_ph(df)
     assert res_df.columns.get_loc('ph') == 0
     assert_approx_equal(res_df['ph'][1], _LOG32, significant=5)
     assert_approx_equal(res_df['ph'][2], _LOG72, significant=5)
     assert_approx_equal(res_df['ph'][3], _LOG121, significant=5)
 
 
+def test_aggbycols_func_scaler():
+    """Testing AggByCols pipeline stages."""
+    df = ph_df()
+    min_ph = AggByCols("ph", min)
+    res_df = min_ph(df)
+    assert res_df.columns.get_loc('ph') == 0
+    assert res_df['ph'][1], min(res_df['ph'])
+    assert res_df['ph'][2], min(res_df['ph'])
+    assert res_df['ph'][3], min(res_df['ph'])
+
+
 def test_aggbycols_func_desc():
     """Testing AggByCols pipeline stages."""
     df = ph_df()
-    round_ph = AggByCols("ph", np.log, func_desc='Round PH values')
-    res_df = round_ph(df)
+    log_ph = AggByCols("ph", np.log, func_desc='Round PH values')
+    res_df = log_ph(df)
     assert res_df.columns.get_loc('ph') == 0
     assert_approx_equal(res_df['ph'][1], _LOG32, significant=5)
     assert_approx_equal(res_df['ph'][2], _LOG72, significant=5)
@@ -46,8 +57,8 @@ def test_aggbycols_func_desc():
 def test_aggbycols_with_result_columns():
     """Testing AggByCols pipeline stages."""
     df = ph_df()
-    round_ph = AggByCols("ph", np.log, result_columns='log_ph')
-    res_df = round_ph(df)
+    log_ph = AggByCols("ph", np.log, result_columns='log_ph')
+    res_df = log_ph(df)
     assert 'ph' not in res_df.columns
     assert res_df.columns.get_loc('log_ph') == 0
     assert_approx_equal(res_df['log_ph'][1], _LOG32, significant=5)
@@ -58,8 +69,8 @@ def test_aggbycols_with_result_columns():
 def test_aggbycols_with_drop():
     """Testing AggByCols pipeline stages."""
     df = ph_df()
-    round_ph = AggByCols("ph", np.log, drop=False)
-    res_df = round_ph(df)
+    log_ph = AggByCols("ph", np.log, drop=False)
+    res_df = log_ph(df)
     assert 'ph' in res_df.columns
     assert 'ph_agg' in res_df.columns
     assert res_df.columns.get_loc('ph') == 0
@@ -72,8 +83,8 @@ def test_aggbycols_with_drop():
 def test_aggbycols_no_drop_custom_suffix():
     """Testing AggByCols pipeline stages."""
     df = ph_df()
-    round_ph = AggByCols("ph", np.log, drop=False, suffix='_log')
-    res_df = round_ph(df)
+    log_ph = AggByCols("ph", np.log, drop=False, suffix='_log')
+    res_df = log_ph(df)
     assert 'ph' in res_df.columns
     assert 'ph_log' in res_df.columns
     assert res_df.columns.get_loc('ph') == 0

--- a/tests/col_generation/test_mapcolvals.py
+++ b/tests/col_generation/test_mapcolvals.py
@@ -96,3 +96,24 @@ def test_mapcolvals_with_method_name():
     assert res_df['Duration']['UK'] == df['Duration']['UK'].total_seconds()
     assert res_df['Duration']['USSR'] == df['Duration']['USSR'].total_seconds()
     assert res_df['Duration']['US'] == df['Duration']['US'].total_seconds()
+
+
+def _3rd_test_df():
+    return pd.DataFrame(
+        data=[
+            [datetime.timedelta(weeks=2)],
+            [datetime.timedelta(weeks=4)],
+            [datetime.timedelta(weeks=10)]
+        ],
+        index=['proposal', 'midterm', 'finals'],
+        columns=['Due'],
+    )
+
+
+def test_mapcolvals_with_method_name_for_documentation():
+    """Testing MapColVals pipeline stages."""
+    df = _3rd_test_df()
+    res_df = MapColVals('Due', ('total_seconds', {})).apply(df)
+    assert res_df['Due']['proposal'] == df['Due']['proposal'].total_seconds()
+    assert res_df['Due']['midterm'] == df['Due']['midterm'].total_seconds()
+    assert res_df['Due']['finals'] == df['Due']['finals'].total_seconds()

--- a/tests/skintegrate/test_pdpipeline_and_sklearn_estimator.py
+++ b/tests/skintegrate/test_pdpipeline_and_sklearn_estimator.py
@@ -18,7 +18,7 @@ from pdpipe.skintegrate import (
 )
 
 
-DF = pd.DataFrame(
+DF1 = pd.DataFrame(
     data=[
         [23, 'Jo', 'M', True, 0.07, 'USA', 'Living life to its fullest'],
         [52, 'Regina', 'F', False, 0.26, 'Germany', 'I hate cats'],
@@ -91,7 +91,7 @@ def test_pdpipeline_and_sklearn_model():
     assert isinstance(repr(mp), str)
 
     # X-y subsets
-    df = DF.copy()
+    df = DF1.copy()
     x_lbls = ['Age', 'Gender', 'Savings', 'Country']
     all_x = df[x_lbls]
     all_y = df['Smoking']
@@ -149,3 +149,23 @@ def test_pdpipeline_and_sklearn_model():
     assert isinstance(gcv.best_estimator_, PdPipelineAndSklearnEstimator)
     score2 = gcv.best_score_
     assert score2 < score1
+
+
+DF2 = pd.DataFrame(
+    data=[['-1',0], ['-1',0], ['1',1], ['1',1]],
+    index=[1, 2, 3, 4],
+    columns=['feature1', 'target']
+)
+
+def test_pdpipeline_and_sklearn_model_documentation():
+    all_x = DF2[['feature1']]
+    all_y = DF2['target']
+    mp = PdPipelineAndSklearnEstimator(
+        pipeline=pdp.ColumnDtypeEnforcer({'feature1': int}),
+        estimator=LogisticRegression()
+    )
+    mp.fit(all_x, all_y)
+    res = mp.predict(all_x)
+    assert isinstance(res, np.ndarray)
+    assert len(res) == len(DF2)
+    assert res.dtype == all_y.dtype

--- a/tests/text_stages/test_regex_replace.py
+++ b/tests/text_stages/test_regex_replace.py
@@ -41,6 +41,13 @@ DF2 = pd.DataFrame(
 )
 
 
+DF3 = pd.DataFrame(
+    data=[["Mr. John", 18], ["MR. Bob", 25]],
+    index=[1, 2],
+    columns=["name","age"],
+)
+
+
 def test_regex_replace_with_flags():
     tokenizer = pdp.RegexReplace('text', r'.+', "TOKEN")
     res_df = tokenizer(DF2)
@@ -56,3 +63,11 @@ def test_regex_replace_with_flags():
     assert 'text' in res_df.columns
     assert res_df.loc[1]['text'] == 'TOKEN'
     assert res_df.loc[2]['text'] == 'TOKEN'
+
+    # documentation example
+    tokenizer = pdp.RegexReplace('name', r'^mr.*', "x", flags=re.IGNORECASE)
+    res_df = tokenizer(DF3)
+    assert 'name' in res_df.columns
+    assert 'age' in res_df.columns
+    assert res_df.loc[1]['name'] == 'x'
+    assert res_df.loc[2]['name'] == 'x'


### PR DESCRIPTION
# Summary
Issue #28
- Fix spellings
- Fix docstrings
  - Example: Missing `callable` in `columns : str or iterable, optional`
- Add code examples when use cases are complex
  - Trying to use existing tests when possible
  - If cannot, tests are added
- Enable links for crucial references
  - Example: pdpipe.cq to `pdpipe.cq`

### Progress
- [x] documentation.md
- [x] pdpipe.basic_stages
- [x] pdpipe.col_generation
- [x] pdpipe.cond
- [x] pdpipe.core
- [x] pdpipe.cq
- [x] pdpipe.nltk_stages
- [x] pdpipe.skintegrate
- [x] pdpipe.sklearn_stages
- [x] pdpipe.text_stages
- [x] pdpipe.wrappers
