### PR TITLE
[WIP] Add more informative texts for failing Conditions

### DIFF
--- a/tests/core/test_pipeline_stage.py
+++ b/tests/core/test_pipeline_stage.py
@@ -8,6 +8,7 @@ from pdpipe.core import (
     FailedPreconditionError,
     FailedPostconditionError,
 )
+from pdpipe.cond import Condition
 
 
 def _test_df():
@@ -255,3 +256,33 @@ def test_failing_postcond():
 
     with pytest.raises(FailedPostconditionError):
         stage.transform(_test_df2(), exraise=True)
+
+
+def test_prec_condition_error_message():
+    stage = SomeStage(prec=Condition(_no_a_in_cols))
+    generic_err = "Precondition failed .*"
+    with pytest.raises(FailedPreconditionError, match=generic_err):
+        stage(_test_df2())
+
+    error_message = "No 'a' in columns"
+    stage = SomeStage(
+        prec=Condition(_no_a_in_cols, error_message=error_message)
+    )
+    specific_err = "Precondition failed .* " + error_message
+    with pytest.raises(FailedPreconditionError, match=specific_err):
+        stage(_test_df2())
+
+
+def test_post_condition_error_message():
+    stage = SomeStage(post=Condition(_no_a_in_cols))
+    generic_err = "Postcondition failed .*"
+    with pytest.raises(FailedPostconditionError, match=generic_err):
+        stage(_test_df2())
+
+    error_message = "No 'a' in columns"
+    stage = SomeStage(
+        post=Condition(_no_a_in_cols, error_message=error_message)
+    )
+    specific_err = "Postcondition failed .* " + error_message
+    with pytest.raises(FailedPostconditionError, match=specific_err):
+        stage(_test_df2())


### PR DESCRIPTION
# WIP

### Summary
Issue #68 

### Changes
Add a new keyword argument `error_message` to the Condition class which provides a descriptive text for a failing condition.

Modify the `PdPipelineStage` such that when `prec` or `post` conditions fail and the respective descriptive error texts exist, display those instead.

Add tests accordingly. 

### Comment
After creating the PR, I realized that we may need to figure out #70 first?