### PR TITLE
fix: handle NaN values in Imputer (#133) by PninaGottfried

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+# Tests intentionally use bare asserts; skip B101 (`assert_used`) globally.
+skips = B101

--- a/src/pdpipe/__init__.py
+++ b/src/pdpipe/__init__.py
@@ -94,6 +94,7 @@ try:
         TfidfVectorizeTokenLists,
         Decompose,
         EncodeLabel,
+        Imputer,
     )
 
     core.__load_stage_attributes_from_module__("pdpipe.sklearn_stages")
@@ -154,6 +155,7 @@ __all__ = [
     "TfidfVectorizeTokenLists",
     "Decompose",
     "EncodeLabel",
+    "Imputer",
 ]
 
 

--- a/src/pdpipe/sklearn_stages.py
+++ b/src/pdpipe/sklearn_stages.py
@@ -17,6 +17,7 @@ from sklearn.base import clone
 from sklearn.feature_extraction.text import (
     TfidfVectorizer,
 )
+from sklearn.impute import SimpleImputer
 from skutil.preprocessing import scaler_by_params
 from tqdm.autonotebook import tqdm
 
@@ -147,6 +148,140 @@ class Encode(ColumnsBasedPipelineStage):
                 loc=loc,
                 column_name=new_name,
             )
+        return inter_X
+
+
+class Imputer(ColumnsBasedPipelineStage):
+    """A pipeline stage that imputes missing values in columns.
+
+    This stage uses scikit-learn's SimpleImputer to handle missing values
+    (NaN, None) in the specified columns with a chosen strategy.
+
+    Parameters
+    ----------
+    strategy : str, default 'mean'
+        The imputation strategy. One of 'mean', 'median', 'most_frequent', or
+        'constant'. Refer to scikit-learn's SimpleImputer documentation for
+        usage details.
+    columns : single label, list-like or callable, default None
+        Column labels in the DataFrame to be imputed. If columns is None then
+        all columns will be imputed, except those given in the
+        exclude_columns parameter. Alternatively, this parameter can be
+        assigned a callable returning an iterable of labels from an input
+        pandas.DataFrame. See `pdpipe.cq`.
+    exclude_columns : single label, list-like or callable, default None
+        Label or labels of columns to be excluded from imputation. Alternatively,
+        this parameter can be assigned a callable returning an iterable of
+        labels from an input pandas.DataFrame. See `pdpipe.cq`.
+    fill_value : str or number, default None
+        The value to use for the 'constant' strategy. Must be provided if
+        strategy is 'constant'.
+    **kwargs : extra keyword arguments
+        All valid extra keyword arguments are forwarded to the SimpleImputer
+        constructor on imputer creation. PdPipelineStage valid keyword arguments
+        are used to override Imputer class defaults.
+
+    Attributes
+    ----------
+    imputer_ : sklearn.impute.SimpleImputer
+        A scikit-learn SimpleImputer object.
+
+    Examples
+    --------
+    >>> import pandas as pd; import numpy as np; import pdpipe as pdp;
+    >>> data = [[1.0, np.nan], [2.0, 4.0], [np.nan, 6.0]]
+    >>> df = pd.DataFrame(data, [1,2,3], ["x","y"])
+    >>> impute_stage = pdp.Imputer("mean")
+    >>> impute_stage(df)
+         x    y
+    1  1.0  5.0
+    2  2.0  4.0
+    3  1.5  6.0
+
+    """
+
+    def __init__(
+        self,
+        strategy="mean",
+        columns=None,
+        exclude_columns=None,
+        fill_value=None,
+        **kwargs,
+    ):
+        self.strategy = strategy
+        self.fill_value = fill_value
+        self._kwargs = kwargs.copy()
+        super_kwargs = {
+            "columns": columns,
+            "exclude_columns": exclude_columns,
+            "desc_temp": "Impute columns {}",
+        }
+        valid_super_kwargs = super()._init_kwargs()
+        for key in kwargs:
+            if key in valid_super_kwargs:
+                super_kwargs[key] = kwargs[key]
+                self._kwargs.pop(key)
+        super().__init__(**super_kwargs)
+
+    def _transformation(self, X, verbose, fit):
+        raise NotImplementedError
+
+    def _fit_transform(self, X, verbose):
+        self._columns_to_impute = self._get_columns(X, fit=True)
+        unimputed_cols = [
+            x for x in X.columns if x not in self._columns_to_impute
+        ]
+        col_order = list(X.columns)
+        inter_X = X[self._columns_to_impute].copy()
+
+        imputer_kwargs = self._kwargs.copy()
+        if self.fill_value is not None:
+            imputer_kwargs["fill_value"] = self.fill_value
+
+        self.imputer_ = SimpleImputer(strategy=self.strategy, **imputer_kwargs)
+        try:
+            inter_X = pd.DataFrame(
+                data=self.imputer_.fit_transform(inter_X.values),
+                index=inter_X.index,
+                columns=inter_X.columns,
+            )
+        except Exception as e:
+            raise PipelineApplicationError(
+                "Exception raised when Imputer applied to columns"
+                f" {self._columns_to_impute} by class {self.__class__}"
+            ) from e
+
+        if len(unimputed_cols) > 0:
+            unimputed = X[unimputed_cols]
+            inter_X = pd.concat([inter_X, unimputed], axis=1)
+            inter_X = inter_X[col_order]
+
+        self.is_fitted = True
+        return inter_X
+
+    def _transform(self, X, verbose):
+        unimputed_cols = [
+            x for x in X.columns if x not in self._columns_to_impute
+        ]
+        col_order = list(X.columns)
+        inter_X = X[self._columns_to_impute].copy()
+        try:
+            inter_X = pd.DataFrame(
+                data=self.imputer_.transform(inter_X.values),
+                index=inter_X.index,
+                columns=inter_X.columns,
+            )
+        except Exception as e:
+            raise PipelineApplicationError(
+                "Exception raised when Imputer applied to columns"
+                f" {self._columns_to_impute} by class {self.__class__}"
+            ) from e
+
+        if len(unimputed_cols) > 0:
+            unimputed = X[unimputed_cols]
+            inter_X = pd.concat([inter_X, unimputed], axis=1)
+            inter_X = inter_X[col_order]
+
         return inter_X
 
 

--- a/src/pdpipe/sklearn_stages.py
+++ b/src/pdpipe/sklearn_stages.py
@@ -217,6 +217,7 @@ class Imputer(ColumnsBasedPipelineStage):
             "columns": columns,
             "exclude_columns": exclude_columns,
             "desc_temp": "Impute columns {}",
+            "none_columns": "all",
         }
         valid_super_kwargs = super()._init_kwargs()
         for key in kwargs:

--- a/src/pdpipe/sklearn_stages.py
+++ b/src/pdpipe/sklearn_stages.py
@@ -170,7 +170,8 @@ class Imputer(ColumnsBasedPipelineStage):
         assigned a callable returning an iterable of labels from an input
         pandas.DataFrame. See `pdpipe.cq`.
     exclude_columns : single label, list-like or callable, default None
-        Label or labels of columns to be excluded from imputation. Alternatively,
+        Label or labels of columns to be excluded from imputation.
+        Alternatively,
         this parameter can be assigned a callable returning an iterable of
         labels from an input pandas.DataFrame. See `pdpipe.cq`.
     fill_value : str or number, default None
@@ -178,7 +179,8 @@ class Imputer(ColumnsBasedPipelineStage):
         strategy is 'constant'.
     **kwargs : extra keyword arguments
         All valid extra keyword arguments are forwarded to the SimpleImputer
-        constructor on imputer creation. PdPipelineStage valid keyword arguments
+        constructor on imputer creation. PdPipelineStage valid keyword
+        arguments
         are used to override Imputer class defaults.
 
     Attributes

--- a/tests/sklearn_stages/test_imputer.py
+++ b/tests/sklearn_stages/test_imputer.py
@@ -122,6 +122,16 @@ def test_imputer_all_columns():
     assert res_df["y"].isna().sum() == 0
 
 
+def test_imputer_defaults_to_all_columns():
+    """Test default columns behavior."""
+    df = _some_df_with_nans_all_cols()
+    imputer_stage = Imputer("mean")
+    res_df = imputer_stage(df)
+
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+
 def test_imputer_constant_strategy():
     """Test imputation with constant strategy."""
     df = _some_df_with_nans()

--- a/tests/sklearn_stages/test_imputer.py
+++ b/tests/sklearn_stages/test_imputer.py
@@ -1,11 +1,9 @@
 """Testing Imputer pipeline stage."""
 
-import pytest
 import pandas as pd
 import numpy as np
 
 from pdpipe.sklearn_stages import Imputer
-from pdpipe.exceptions import PipelineApplicationError
 
 
 def _some_df_with_nans():
@@ -64,7 +62,7 @@ def test_imputer_mean_transform():
     """Test imputation transform with mean strategy."""
     df = _some_df_with_nans()
     imputer_stage = Imputer("mean", columns=["x", "y"])
-    res_df = imputer_stage(df)
+    imputer_stage(df)
 
     # Apply to new data using fitted imxxxxr
     df2 = _some_df_with_nans_b()

--- a/tests/sklearn_stages/test_imputer.py
+++ b/tests/sklearn_stages/test_imputer.py
@@ -1,0 +1,194 @@
+"""Testing Imputer pipeline stage."""
+
+import pytest
+import pandas as pd
+import numpy as np
+
+from pdpipe.sklearn_stages import Imputer
+from pdpipe.exceptions import PipelineApplicationError
+
+
+def _some_df_with_nans():
+    return pd.DataFrame(
+        data=[[1.0, np.nan, "A"], [2.0, 4.0, "B"], [np.nan, 6.0, "C"]],
+        index=[1, 2, 3],
+        columns=["x", "y", "lbl"],
+    )
+
+
+def _some_df_with_nans_all_cols():
+    return pd.DataFrame(
+        data=[[np.nan, np.nan], [2.0, 4.0], [np.nan, 6.0]],
+        index=[1, 2, 3],
+        columns=["x", "y"],
+    )
+
+
+def _some_df_with_nans_b():
+    return pd.DataFrame(
+        data=[[3.0, np.nan, "D"], [5.0, 8.0, "E"], [np.nan, 10.0, "F"]],
+        index=[1, 2, 3],
+        columns=["x", "y", "lbl"],
+    )
+
+
+def _some_df_no_nans():
+    return pd.DataFrame(
+        data=[[1.0, 2.0, "A"], [3.0, 4.0, "B"], [5.0, 6.0, "C"]],
+        index=[1, 2, 3],
+        columns=["x", "y", "lbl"],
+    )
+
+
+def test_imputer_mean():
+    """Test imputation with mean strategy."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Check that NaNs are imputed
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+    # Check column names preserved
+    assert list(res_df.columns) == ["x", "y", "lbl"]
+
+    # Check that mean imputation occurred correctly
+    # mean of [1.0, 2.0, nan] = 1.5
+    assert res_df["x"][3] == 1.5
+    # mean of [nan, 4.0, 6.0] = 5.0
+    assert res_df["y"][1] == 5.0
+
+
+def test_imputer_mean_transform():
+    """Test imputation transform with mean strategy."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Apply to new data using fitted imxxxxr
+    df2 = _some_df_with_nans_b()
+    res_df2 = imputer_stage(df2)
+
+    # Check that NaNs are imputed in new data
+    assert res_df2["x"].isna().sum() == 0
+    assert res_df2["y"].isna().sum() == 0
+
+    # The imputation should use the mean from the first fit
+    # mean of x from df = 1.5, so NaN at index 3 in df2 should become 1.5
+    assert res_df2["x"][3] == 1.5
+
+
+def test_imputer_median():
+    """Test imputation with median strategy."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("median", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Check that NaNs are imputed
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+    # Check column names preserved
+    assert list(res_df.columns) == ["x", "y", "lbl"]
+
+    # Check that median imputation occurred correctly
+    # median of [1.0, 2.0, nan] = 1.5
+    assert res_df["x"][3] == 1.5
+    # median of [nan, 4.0, 6.0] = 5.0
+    assert res_df["y"][1] == 5.0
+
+
+def test_imputer_with_exclude_cols():
+    """Test imputation with excluded columns."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns=["x", "y"], exclude_columns=["y"])
+    res_df = imputer_stage(df)
+
+    # Check that only x is imputed (y is excluded)
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 1  # y should still have NaN
+
+    # Check column order preserved
+    assert list(res_df.columns) == ["x", "y", "lbl"]
+
+
+def test_imputer_all_columns():
+    """Test imputation with all numeric columns."""
+    df = _some_df_with_nans_all_cols()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Check that NaNs are imputed in all columns
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+
+def test_imputer_constant_strategy():
+    """Test imputation with constant strategy."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("constant", columns=["x", "y"], fill_value=0)
+    res_df = imputer_stage(df)
+
+    # Check that NaNs are imputed with constant value
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+    # Check that NaN values were replaced with fill_value
+    assert res_df["x"][3] == 0
+    assert res_df["y"][1] == 0
+
+
+def test_imputer_most_frequent():
+    """Test imputation with most_frequent strategy."""
+    df = pd.DataFrame(
+        data=[[1.0, np.nan], [1.0, 2.0], [np.nan, 2.0]],
+        index=[1, 2, 3],
+        columns=["x", "y"],
+    )
+    imputer_stage = Imputer("most_frequent", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Check that NaNs are imputed
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+
+
+def test_imputer_no_nans():
+    """Test imputation on data with no NaNs."""
+    df = _some_df_no_nans()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    res_df = imputer_stage(df)
+
+    # Check that data is unchanged
+    pd.testing.assert_frame_equal(res_df, df)
+
+
+def test_imputer_fit_transform():
+    """Test fit_transform on same data."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+
+    # First fit_transform
+    res_df1 = imputer_stage.fit_transform(df)
+    assert res_df1["x"].isna().sum() == 0
+
+    # Second fit_transform with new data
+    df2 = _some_df_with_nans_b()
+    res_df2 = imputer_stage.fit_transform(df2)
+    assert res_df2["x"].isna().sum() == 0
+
+    # Values should be different because it refitted on df2
+    assert res_df2["x"][3] != res_df1["x"][3]
+
+
+def test_imputer_with_single_column():
+    """Test imputation with a single column."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns="x")
+    res_df = imputer_stage(df)
+
+    # Check that only specified column is imputed
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 1  # y should still have NaN
+    assert list(res_df.columns) == ["x", "y", "lbl"]

--- a/tests/sklearn_stages/test_imputer.py
+++ b/tests/sklearn_stages/test_imputer.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import numpy as np
 
+from pdpipe.exceptions import PipelineApplicationError
 from pdpipe.sklearn_stages import Imputer
 
 
@@ -130,6 +131,60 @@ def test_imputer_defaults_to_all_columns():
 
     assert res_df["x"].isna().sum() == 0
     assert res_df["y"].isna().sum() == 0
+
+
+def test_imputer_transform_with_only_selected_columns():
+    """Test transform path with no unimputed columns."""
+    df = _some_df_with_nans_all_cols()
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    imputer_stage(df)
+    res_df = imputer_stage(df)
+
+    assert res_df["x"].isna().sum() == 0
+    assert res_df["y"].isna().sum() == 0
+    assert list(res_df.columns) == ["x", "y"]
+
+
+def test_imputer_kwargs_split_between_stage_and_imputer():
+    """Test that stage kwargs are consumed and imputer kwargs remain."""
+    imputer_stage = Imputer(
+        "mean",
+        columns=["x", "y"],
+        exmsg="custom message",
+        missing_values=np.nan,
+    )
+    assert "exmsg" not in imputer_stage._kwargs
+    assert imputer_stage._kwargs["missing_values"] is np.nan
+
+
+def test_imputer_fit_failure_raises_pipeline_application_error():
+    """Test fit failure handling."""
+    df = _some_df_with_nans()
+    imputer_stage = Imputer("mean", columns=["x", "lbl"])
+
+    try:
+        imputer_stage(df)
+        assert False, "Expected PipelineApplicationError"
+    except PipelineApplicationError:
+        assert True
+
+
+def test_imputer_transform_failure_raises_pipeline_application_error():
+    """Test transform failure handling."""
+    fit_df = _some_df_with_nans_all_cols()
+    transform_df = pd.DataFrame(
+        data=[["A", np.nan], ["B", 4.0], ["C", 6.0]],
+        index=[1, 2, 3],
+        columns=["x", "y"],
+    )
+    imputer_stage = Imputer("mean", columns=["x", "y"])
+    imputer_stage(fit_df)
+
+    try:
+        imputer_stage(transform_df)
+        assert False, "Expected PipelineApplicationError"
+    except PipelineApplicationError:
+        assert True
 
 
 def test_imputer_constant_strategy():


### PR DESCRIPTION
* fix: handle NaN values in Imputer

resolves #13

- Improves Imputer logic to correctly handle NaN values.
- Adds unit tests covering NaN-related edge cases.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

by [PninaGottfried](https://github.com/PninaGottfried)