### PR TITLE
Add AGENTS setup and LOCAL_AGENTS template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Pipfile.lock
 notebooks/debug*.py
 
 .mypy_cache/
+
+# Local agent overrides
+LOCAL_AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - pdpipe
+
+This file defines contributor and coding-agent rules for this repository.
+
+## Scope and intent
+- Keep changes focused, minimal, and test-backed.
+- Preserve backward compatibility unless the issue or PR explicitly allows breaking changes.
+- Prefer clear, deterministic behavior over implicit magic.
+
+## Project basics
+- Package: `pdpipe`
+- Purpose: easy pipelines for pandas DataFrames.
+- Python: CI-supported versions in this repo.
+- Optional extras: `nltk`, `sklearn`.
+- Primary source path: `src/pdpipe/`.
+
+## Repository layout
+
+```
+pdpipe/
+├── src/pdpipe/            # Source package
+│   ├── core.py            # Pipeline and stage core abstractions
+│   ├── basic_stages.py    # Core dataframe transformation stages
+│   ├── col_generation.py  # Column/feature generation stages
+│   ├── nltk_stages.py     # NLTK-dependent text stages
+│   ├── sklearn_stages.py  # sklearn-dependent stages
+│   ├── skintegrate.py     # sklearn estimator integration wrapper
+│   ├── cond.py / cq.py / rq.py
+│   └── ...
+├── tests/                 # Pytest suite
+├── docs/                  # Documentation
+├── dev/                   # Developer scripts
+├── .github/workflows/     # CI workflows
+└── pyproject.toml         # Build + lint + test configuration
+```
+
+## Core quality requirements
+- Lint/format before every commit:
+  - `python -m black .`
+  - `python -m flake8`
+- Run relevant tests for touched code.
+- Keep doctest examples valid for touched modules.
+
+## CI workflows
+- `test.yml`: main test matrix.
+- `lint.yml`: flake8 checks.
+- `black.yml`: formatting check.
+- `npdocval.yml`: numpydoc validation.
+- `release.yml`: release workflow.
+
+## Coding expectations
+- Favor explicit, readable implementations.
+- Keep behavior deterministic and backward-compatible by default.
+- Add regression tests for bug fixes.
+- Keep optional dependencies optional; degrade gracefully when unavailable.
+
+## PR expectations
+- One logical change per PR.
+- Clear summary of behavior changes and test evidence.
+- Green CI before merge.
+
+## Local overrides (optional, untracked)
+- If `LOCAL_AGENTS.md` exists at repo root, treat it as additive local instructions.
+- `LOCAL_AGENTS.md` should remain untracked.
+- On conflicts, repository/security policy takes precedence.
+
+## Security and secrets
+- Never commit credentials or machine-specific secrets.
+- Avoid weakening protections around sensitive files or env vars.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 This file defines contributor and coding-agent rules for this repository.
 
 ## Scope and intent
+
 - Keep changes focused, minimal, and test-backed.
 - Preserve backward compatibility unless the issue or PR explicitly allows breaking changes.
 - Prefer clear, deterministic behavior over implicit magic.
 
 ## Project basics
+
 - Package: `pdpipe`
 - Purpose: easy pipelines for pandas DataFrames.
 - Python: CI-supported versions in this repo.
@@ -35,6 +37,7 @@ pdpipe/
 ```
 
 ## Core quality requirements
+
 - Lint/format before every commit:
   - `python -m black .`
   - `python -m flake8`
@@ -42,6 +45,7 @@ pdpipe/
 - Keep doctest examples valid for touched modules.
 
 ## CI workflows
+
 - `test.yml`: main test matrix.
 - `lint.yml`: flake8 checks.
 - `black.yml`: formatting check.
@@ -49,21 +53,25 @@ pdpipe/
 - `release.yml`: release workflow.
 
 ## Coding expectations
+
 - Favor explicit, readable implementations.
 - Keep behavior deterministic and backward-compatible by default.
 - Add regression tests for bug fixes.
 - Keep optional dependencies optional; degrade gracefully when unavailable.
 
 ## PR expectations
+
 - One logical change per PR.
 - Clear summary of behavior changes and test evidence.
 - Green CI before merge.
 
 ## Local overrides (optional, untracked)
+
 - If `LOCAL_AGENTS.md` exists at repo root, treat it as additive local instructions.
 - `LOCAL_AGENTS.md` should remain untracked.
 - On conflicts, repository/security policy takes precedence.
 
 ## Security and secrets
+
 - Never commit credentials or machine-specific secrets.
 - Avoid weakening protections around sensitive files or env vars.

--- a/LOCAL_AGENTS.example.md
+++ b/LOCAL_AGENTS.example.md
@@ -1,0 +1,12 @@
+# LOCAL_AGENTS.example.md
+
+Copy this file to `LOCAL_AGENTS.md` for machine-specific agent instructions.
+`LOCAL_AGENTS.md` is intentionally untracked.
+
+## Optional local MCP routing
+- For this repo, prefer a local git MCP namespace like `mcp__git_<your_server>__*` (replace `<your_server>` with your local MCP server name).
+- Use GitHub MCP for remote operations.
+
+## Optional local workflow preferences
+- Prefer MCP tools over shell when both are available.
+- Use local Python environment and tooling preferences as needed.

--- a/LOCAL_AGENTS.example.md
+++ b/LOCAL_AGENTS.example.md
@@ -4,9 +4,11 @@ Copy this file to `LOCAL_AGENTS.md` for machine-specific agent instructions.
 `LOCAL_AGENTS.md` is intentionally untracked.
 
 ## Optional local MCP routing
+
 - For this repo, prefer a local git MCP namespace like `mcp__git_<your_server>__*` (replace `<your_server>` with your local MCP server name).
 - Use GitHub MCP for remote operations.
 
 ## Optional local workflow preferences
+
 - Prefer MCP tools over shell when both are available.
 - Use local Python environment and tooling preferences as needed.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository-specific coding-agent guidance
- add LOCAL_AGENTS.example.md as the tracked local-override template
- add LOCAL_AGENTS.md to .gitignore so machine-local overrides stay untracked

## Notes
- This PR intentionally does not track LOCAL_AGENTS.md.
- Keeps local-agent workflow aligned with the foldermix pattern.