### PR TITLE
test: split test_issue_70.py from PR #123

### DIFF
--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -286,11 +286,10 @@ class PdPipelineStage(abc.ABC):
         does not hold for an output dataframe (after pipeline application).
         Otherwise pipeline application continues uninterrupted.
     exmsg : str, default None
-        The message of the exception raised when this stage-level application
-        fails and exraise is set to True. This message is used for built-in
-        stage condition failures; user-provided condition objects are expected
-        to provide their own messages. A default message is used if None is
-        given.
+        The message of the exception raised when this stage application fails
+        and exraise is set to True. User-provided condition objects are
+        expected to provide their own messages. A default message is used if
+        None is given.
     desc : str, default None
         A short description of this stage, used as its string representation.
         A default description is used if None is given.
@@ -364,6 +363,8 @@ class PdPipelineStage(abc.ABC):
         self._skip = skip
         self._appmsg = f"{name + ': ' if name else ''}{desc}"
         self._name = name
+        self._failed_precondition = None
+        self._failed_postcondition = None
 
         # inner stuff initializations
         self._is_an_Xy_transformer = False
@@ -486,85 +487,79 @@ class PdPipelineStage(abc.ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
-    def _run_cond_callable(
-        cond: callable,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-        fit: Optional[bool] = False,
-    ) -> bool:
-        """Execute a condition callable with backwards-compatible
-        signatures."""
-        to_call = cond
-        if fit:
-            try:
-                to_call = cond.fit_transform
-            except AttributeError:
-                pass
-        try:
-            return to_call(X, y)
-        except TypeError as e:
-            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                return to_call(X)
-            raise e  # pragma: no cover
-
-    @staticmethod
-    def _run_stage_cond(
-        cond: callable,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-    ) -> bool:
-        """Execute a stage condition method with backwards-compatible
-        signatures."""
-        if y is None:
-            try:
-                return cond(X)
-            except TypeError as e:
-                if (
-                    len(PdPipelineStage._MISSING_POS_ARG_PAT.findall(str(e)))
-                    > 0
-                ):
-                    return cond(X, y)
-                raise e
-        try:
-            return cond(X, y)
-        except TypeError as e:
-            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                return cond(X)
-            raise e  # pragma: no cover
-
-    def _check_user_precondition(
-        self,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-        fit: Optional[bool] = False,
-    ) -> bool:
-        if not self._prec_arg:
-            return True
-        return self._run_cond_callable(cond=self._prec_arg, X=X, y=y, fit=fit)
-
-    def _check_stage_precondition(
-        self,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-    ) -> bool:
-        return self._run_stage_cond(cond=self._prec, X=X, y=y)
-
     def _compound_prec(
         self,
         X: pandas.DataFrame,
         y: Optional[pandas.Series] = None,
         fit: Optional[bool] = False,
     ) -> bool:
-        """Return True if both user and stage preconditions hold."""
-        return self._check_user_precondition(
-            X=X,
-            y=y,
-            fit=fit,
-        ) and self._check_stage_precondition(
-            X=X,
-            y=y,
-        )
+        """Return True if the input dataframe conforms to stage pre-condition.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame
+            The dataframe to transform.
+        y : pandas.Series, optional
+            A possible label column for processing of supervised learning
+            datasets. Might also be inspected, if provided.
+        fit : bool
+            If set to True, then this pre-condition check is understood to be
+            performed during a fit-transform operation. Otherwise, it is
+            assumed this is being performed during a transform operation.
+            Optional. Set to False by default.
+
+        Returns
+        -------
+        bool
+            True if the input dataframe conforms to stage pre-condition; False
+            otherwise.
+
+        """
+        self._failed_precondition = None
+
+        if self._prec_arg:
+            to_call = self._prec_arg
+            if fit:
+                try:
+                    to_call = self._prec_arg.fit_transform
+                except AttributeError:
+                    pass
+            try:
+                user_holds = to_call(X, y)
+            except TypeError as e:
+                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                    user_holds = to_call(X)
+                else:
+                    raise e  # pragma: no cover
+            if not user_holds:
+                self._failed_precondition = "user"
+                return False
+
+        # now, do the same for the _prec abstractmethod, so as to support
+        # implementations only including X in their signature
+        if y is None:
+            try:
+                stage_holds = self._prec(X)
+            except TypeError as e:
+                if (
+                    len(PdPipelineStage._MISSING_POS_ARG_PAT.findall(str(e)))
+                    > 0
+                ):
+                    # self._prec is hopefully expecting y
+                    stage_holds = self._prec(X, y)
+                else:
+                    raise e  # pragma: no cover
+        else:
+            try:
+                stage_holds = self._prec(X, y)
+            except TypeError as e:
+                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                    stage_holds = self._prec(X)
+                else:
+                    raise e  # pragma: no cover
+        if not stage_holds:
+            self._failed_precondition = "stage"
+        return stage_holds
 
     def _post(
         self,
@@ -590,38 +585,53 @@ class PdPipelineStage(abc.ABC):
         """
         return True
 
-    def _check_user_postcondition(
-        self,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-        fit: Optional[bool] = False,
-    ) -> bool:
-        if not self._post_arg:
-            return True
-        return self._run_cond_callable(cond=self._post_arg, X=X, y=y, fit=fit)
-
-    def _check_stage_postcondition(
-        self,
-        X: pandas.DataFrame,
-        y: Optional[pandas.Series] = None,
-    ) -> bool:
-        return self._run_stage_cond(cond=self._post, X=X, y=y)
-
     def _compound_post(
         self,
         X: pandas.DataFrame,
         y: Optional[pandas.Series] = None,
         fit: Optional[bool] = False,
     ) -> bool:
-        """Return True if both user and stage postconditions hold."""
-        return self._check_user_postcondition(
-            X=X,
-            y=y,
-            fit=fit,
-        ) and self._check_stage_postcondition(
-            X=X,
-            y=y,
-        )
+        """An inner implementation of the post-condition functionality.
+
+        Uses the constructor provided post-condition, if one was provided.
+        Otherwise, uses the build-it function.
+
+        """
+        self._failed_postcondition = None
+
+        if self._post_arg:
+            to_call = self._post_arg
+            if fit:
+                try:
+                    to_call = self._post_arg.fit_transform
+                except AttributeError:
+                    pass
+            try:
+                user_holds = to_call(X, y)
+            except TypeError as e:
+                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                    user_holds = to_call(X)
+                else:
+                    raise e  # pragma: no cover
+            if not user_holds:
+                self._failed_postcondition = "user"
+                return False
+
+        # now, do the same for the _post abstractmethod, so as to support
+        # implementations only including X in their signature
+        if y is None:
+            stage_holds = self._post(X)
+        else:
+            try:
+                stage_holds = self._post(X, y)
+            except TypeError as e:
+                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                    stage_holds = self._post(X)
+                else:
+                    raise e  # pragma: no cover
+        if not stage_holds:
+            self._failed_postcondition = "stage"
+        return stage_holds
 
     def _fit_transform(
         self,
@@ -650,29 +660,23 @@ class PdPipelineStage(abc.ABC):
             return False
         return True
 
-    def _raise_user_precondition_error(self) -> None:
-        error_message = getattr(self._prec_arg, "_error_message", None)
-        if error_message:
-            raise FailedPreconditionError(error_message)
-        raise FailedPreconditionError("User-provided precondition failed.")
-
-    def _raise_stage_precondition_error(self) -> None:
+    def _raise_precondition_error(self) -> None:
+        if self._failed_precondition == "user":
+            error_message = getattr(self._prec_arg, "_error_message", None)
+            if error_message:
+                raise FailedPreconditionError(error_message)
+            raise FailedPreconditionError("User-provided precondition failed.")
         raise FailedPreconditionError(self._exmsg)
 
-    def _raise_user_postcondition_error(self) -> None:
-        error_message = getattr(self._post_arg, "_error_message", None)
-        if error_message:
-            raise FailedPostconditionError(error_message)
-        raise FailedPostconditionError("User-provided postcondition failed.")
-
-    def _raise_stage_postcondition_error(self) -> None:
-        raise FailedPostconditionError(self._exmsg_post)
-
-    def _raise_precondition_error(self) -> None:
-        self._raise_stage_precondition_error()
-
     def _raise_postcondition_error(self) -> None:
-        self._raise_stage_postcondition_error()
+        if self._failed_postcondition == "user":
+            error_message = getattr(self._post_arg, "_error_message", None)
+            if error_message:
+                raise FailedPostconditionError(error_message)
+            raise FailedPostconditionError(
+                "User-provided postcondition failed."
+            )
+        raise FailedPostconditionError(self._exmsg_post)
 
     @abc.abstractmethod
     def _transform(
@@ -861,41 +865,33 @@ class PdPipelineStage(abc.ABC):
                 return X
             if y is not None:
                 y = self._cast_y_to_series(X, y)
-            if not self._check_user_precondition(X=X, y=y, fit=True):
-                if exraise:
-                    self._raise_user_precondition_error()
+            if self._compound_prec(X, y, fit=True):
+                if verbose:
+                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                    print(msg, flush=True)
+                if self._is_an_Xy_fit_transformer:
+                    res_X, res_y = self._fit_transform_Xy(
+                        X, y, verbose=verbose
+                    )
+                elif self._is_an_Xy_transformer:
+                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
+                else:
+                    res_X = self._fit_transform(X, verbose=verbose)
+                    res_y = y
+                self.is_fitted = True
+                if exraise and not self._compound_post(
+                    X=res_X, y=res_y, fit=True
+                ):
+                    self._raise_postcondition_error()
                 if y is not None:
-                    return X, y
-                return X
-            if not self._check_stage_precondition(X=X, y=y):
-                if exraise:
-                    self._raise_stage_precondition_error()
-                if y is not None:
-                    return X, y
-                return X
-            if verbose:
-                msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                print(msg, flush=True)
-            if self._is_an_Xy_fit_transformer:
-                res_X, res_y = self._fit_transform_Xy(X, y, verbose=verbose)
-            elif self._is_an_Xy_transformer:
-                res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-            else:
-                res_X = self._fit_transform(X, verbose=verbose)
-                res_y = y
-            self.is_fitted = True
-            if exraise and not self._check_user_postcondition(
-                X=res_X, y=res_y, fit=True
-            ):
-                self._raise_user_postcondition_error()
-            if exraise and not self._check_stage_postcondition(
-                X=res_X, y=res_y
-            ):
-                self._raise_stage_postcondition_error()
+                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                    return res_X, res_y
+                return res_X
+            if exraise:
+                self._raise_precondition_error()
             if y is not None:
-                res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                return res_X, res_y
-            return res_X
+                return X, y
+            return X
 
     def fit(self, X, y=None, exraise=None, verbose=False):
         """Fit this stage without transforming the given dataframe.
@@ -962,62 +958,50 @@ class PdPipelineStage(abc.ABC):
                 return X
             if y is not None:
                 y = self._cast_y_to_series(X, y)
-            if not self._check_user_precondition(X=X, y=y):
-                if exraise:
-                    self._raise_user_precondition_error()
+            if self._compound_prec(X, y):
+                if verbose:
+                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                    print(msg, flush=True)
+                if self._is_fittable():
+                    if self.is_fitted:
+                        if self._is_an_Xy_transformer:
+                            res_X, res_y = self._transform_Xy(
+                                X, y, verbose=verbose
+                            )
+                        else:
+                            res_X = self._transform(X, verbose=verbose)
+                            res_y = y
+                        if exraise and not self._compound_post(
+                            X=res_X, y=res_y
+                        ):
+                            self._raise_postcondition_error()
+                        if y is not None:
+                            res_X, res_y = self._align_Xy(
+                                X=res_X, y=res_y, preX=X
+                            )
+                            return res_X, res_y
+                        return res_X
+                    raise UnfittedPipelineStageError(
+                        "transform of an unfitted pipeline stage was called!"
+                    )
+                if self._is_an_Xy_transformer:
+                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
+                else:
+                    res_X = self._transform(X, verbose=verbose)
+                    res_y = y
+                if exraise and not self._compound_post(X=res_X, y=res_y):
+                    self._raise_postcondition_error()
                 if y is not None:
-                    return X, y
-                return X
-            if not self._check_stage_precondition(X=X, y=y):
-                if exraise:
-                    self._raise_stage_precondition_error()
-                if y is not None:
-                    return X, y
-                return X
-            if verbose:
-                msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                print(msg, flush=True)
-            if self._is_fittable():
-                if self.is_fitted:
-                    if self._is_an_Xy_transformer:
-                        res_X, res_y = self._transform_Xy(
-                            X, y, verbose=verbose
-                        )
-                    else:
-                        res_X = self._transform(X, verbose=verbose)
-                        res_y = y
-                    if exraise and not self._check_user_postcondition(
-                        X=res_X, y=res_y
-                    ):
-                        self._raise_user_postcondition_error()
-                    if exraise and not self._check_stage_postcondition(
-                        X=res_X, y=res_y
-                    ):
-                        self._raise_stage_postcondition_error()
-                    if y is not None:
-                        res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                        return res_X, res_y
-                    return res_X
-                raise UnfittedPipelineStageError(
-                    "transform of an unfitted pipeline stage was called!"
-                )
-            if self._is_an_Xy_transformer:
-                res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-            else:
-                res_X = self._transform(X, verbose=verbose)
-                res_y = y
-            if exraise and not self._check_user_postcondition(
-                X=res_X, y=res_y
-            ):
-                self._raise_user_postcondition_error()
-            if exraise and not self._check_stage_postcondition(
-                X=res_X, y=res_y
-            ):
-                self._raise_stage_postcondition_error()
+                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                    return res_X, res_y
+                return res_X
+            if exraise:
+                self._raise_precondition_error()
+            # precondition doesn't hold, but we don't want to raise an error
+            # as exraise is False, so return untransformed X or X, y
             if y is not None:
-                res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                return res_X, res_y
-            return res_X
+                return X, y
+            return X
 
     def __add__(self, other):
         if isinstance(other, PdPipeline):

--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -493,7 +493,8 @@ class PdPipelineStage(abc.ABC):
         y: Optional[pandas.Series] = None,
         fit: Optional[bool] = False,
     ) -> bool:
-        """Execute a condition callable with backwards-compatible signatures."""
+        """Execute a condition callable with backwards-compatible
+        signatures."""
         to_call = cond
         if fit:
             try:
@@ -513,7 +514,8 @@ class PdPipelineStage(abc.ABC):
         X: pandas.DataFrame,
         y: Optional[pandas.Series] = None,
     ) -> bool:
-        """Execute a stage condition method with backwards-compatible signatures."""
+        """Execute a stage condition method with backwards-compatible
+        signatures."""
         if y is None:
             try:
                 return cond(X)
@@ -993,9 +995,7 @@ class PdPipelineStage(abc.ABC):
                     ):
                         self._raise_stage_postcondition_error()
                     if y is not None:
-                        res_X, res_y = self._align_Xy(
-                            X=res_X, y=res_y, preX=X
-                        )
+                        res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
                         return res_X, res_y
                     return res_X
                 raise UnfittedPipelineStageError(

--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -286,9 +286,11 @@ class PdPipelineStage(abc.ABC):
         does not hold for an output dataframe (after pipeline application).
         Otherwise pipeline application continues uninterrupted.
     exmsg : str, default None
-        The message of the exception that is raised on a failed
-        precondition if exraise is set to True. A default message is used
-        if None is given.
+        The message of the exception raised when this stage-level application
+        fails and exraise is set to True. This message is used for built-in
+        stage condition failures; user-provided condition objects are expected
+        to provide their own messages. A default message is used if None is
+        given.
     desc : str, default None
         A short description of this stage, used as its string representation.
         A default description is used if None is given.
@@ -327,7 +329,7 @@ class PdPipelineStage(abc.ABC):
 
     """
 
-    _DEF_EXC_MSG = "Precondition failed in stage {}!"
+    _DEF_EXC_MSG = "Pipeline stage failed in stage {}!"
     _DEF_DESCRIPTION = "A pipeline stage."
     _INIT_KWARGS = ["exraise", "exmsg", "desc", "prec", "skip", "name"]
 
@@ -484,67 +486,83 @@ class PdPipelineStage(abc.ABC):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def _run_cond_callable(
+        cond: callable,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+        fit: Optional[bool] = False,
+    ) -> bool:
+        """Execute a condition callable with backwards-compatible signatures."""
+        to_call = cond
+        if fit:
+            try:
+                to_call = cond.fit_transform
+            except AttributeError:
+                pass
+        try:
+            return to_call(X, y)
+        except TypeError as e:
+            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                return to_call(X)
+            raise e  # pragma: no cover
+
+    @staticmethod
+    def _run_stage_cond(
+        cond: callable,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+    ) -> bool:
+        """Execute a stage condition method with backwards-compatible signatures."""
+        if y is None:
+            try:
+                return cond(X)
+            except TypeError as e:
+                if (
+                    len(PdPipelineStage._MISSING_POS_ARG_PAT.findall(str(e)))
+                    > 0
+                ):
+                    return cond(X, y)
+                raise e
+        try:
+            return cond(X, y)
+        except TypeError as e:
+            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
+                return cond(X)
+            raise e  # pragma: no cover
+
+    def _check_user_precondition(
+        self,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+        fit: Optional[bool] = False,
+    ) -> bool:
+        if not self._prec_arg:
+            return True
+        return self._run_cond_callable(cond=self._prec_arg, X=X, y=y, fit=fit)
+
+    def _check_stage_precondition(
+        self,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+    ) -> bool:
+        return self._run_stage_cond(cond=self._prec, X=X, y=y)
+
     def _compound_prec(
         self,
         X: pandas.DataFrame,
         y: Optional[pandas.Series] = None,
         fit: Optional[bool] = False,
     ) -> bool:
-        """Return True if the input dataframe conforms to stage pre-condition.
-
-        Parameters
-        ----------
-        X : pandas.DataFrame
-            The dataframe to transform.
-        y : pandas.Series, optional
-            A possible label column for processing of supervised learning
-            datasets. Might also be inspected, if provided.
-        fit : bool
-            If set to True, then this pre-condition check is understood to be
-            performed during a fit-transform operation. Otherwise, it is
-            assumed this is being performed during a transform operation.
-            Optional. Set to False by default.
-
-        Returns
-        -------
-        bool
-            True if the input dataframe conforms to stage pre-condition; False
-            otherwise.
-
-        """
-        if self._prec_arg:
-            to_call = self._prec_arg
-            if fit:
-                try:
-                    to_call = self._prec_arg.fit_transform
-                except AttributeError:
-                    pass
-            try:
-                return to_call(X, y)
-            except TypeError as e:
-                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                    return to_call(X)
-                raise e  # pragma: no cover
-
-        # now, do the same for the _prec abstractmethod, so as to support
-        # implementations only including X in their signature
-        if y is None:
-            try:
-                return self._prec(X)
-            except TypeError as e:
-                if (
-                    len(PdPipelineStage._MISSING_POS_ARG_PAT.findall(str(e)))
-                    > 0
-                ):
-                    # self._prec is hopefully expecting y
-                    return self._prec(X, y)
-                raise e
-        try:
-            return self._prec(X, y)
-        except TypeError as e:
-            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                return self._prec(X)
-            raise e  # pragma: no cover
+        """Return True if both user and stage preconditions hold."""
+        return self._check_user_precondition(
+            X=X,
+            y=y,
+            fit=fit,
+        ) and self._check_stage_precondition(
+            X=X,
+            y=y,
+        )
 
     def _post(
         self,
@@ -570,42 +588,38 @@ class PdPipelineStage(abc.ABC):
         """
         return True
 
+    def _check_user_postcondition(
+        self,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+        fit: Optional[bool] = False,
+    ) -> bool:
+        if not self._post_arg:
+            return True
+        return self._run_cond_callable(cond=self._post_arg, X=X, y=y, fit=fit)
+
+    def _check_stage_postcondition(
+        self,
+        X: pandas.DataFrame,
+        y: Optional[pandas.Series] = None,
+    ) -> bool:
+        return self._run_stage_cond(cond=self._post, X=X, y=y)
+
     def _compound_post(
         self,
         X: pandas.DataFrame,
         y: Optional[pandas.Series] = None,
         fit: Optional[bool] = False,
     ) -> bool:
-        """An inner implementation of the post-condition functionality.
-
-        Uses the constructor provided post-condition, if one was provided.
-        Otherwise, uses the build-it function.
-
-        """
-        if self._post_arg:
-            to_call = self._post_arg
-            if fit:
-                try:
-                    to_call = self._post_arg.fit_transform
-                except AttributeError:
-                    pass
-            try:
-                return to_call(X, y)
-            except TypeError as e:
-                if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                    return to_call(X)
-                raise e  # pragma: no cover
-
-        # now, do the same for the _post abstractmethod, so as to support
-        # implementations only including X in their signature
-        if y is None:
-            return self._post(X)
-        try:
-            return self._post(X, y)
-        except TypeError as e:
-            if len(POS_ARG_MISMTCH_PAT.findall(str(e))) > 0:
-                return self._post(X)
-            raise e  # pragma: no cover
+        """Return True if both user and stage postconditions hold."""
+        return self._check_user_postcondition(
+            X=X,
+            y=y,
+            fit=fit,
+        ) and self._check_stage_postcondition(
+            X=X,
+            y=y,
+        )
 
     def _fit_transform(
         self,
@@ -634,21 +648,29 @@ class PdPipelineStage(abc.ABC):
             return False
         return True
 
-    def _raise_precondition_error(self) -> None:
+    def _raise_user_precondition_error(self) -> None:
         error_message = getattr(self._prec_arg, "_error_message", None)
         if error_message:
-            raise FailedPreconditionError(
-                f"{self._exmsg} [Reason] {error_message}"
-            )
+            raise FailedPreconditionError(error_message)
+        raise FailedPreconditionError("User-provided precondition failed.")
+
+    def _raise_stage_precondition_error(self) -> None:
         raise FailedPreconditionError(self._exmsg)
 
+    def _raise_user_postcondition_error(self) -> None:
+        error_message = getattr(self._post_arg, "_error_message", None)
+        if error_message:
+            raise FailedPostconditionError(error_message)
+        raise FailedPostconditionError("User-provided postcondition failed.")
+
+    def _raise_stage_postcondition_error(self) -> None:
+        raise FailedPostconditionError(self._exmsg_post)
+
+    def _raise_precondition_error(self) -> None:
+        self._raise_stage_precondition_error()
+
     def _raise_postcondition_error(self) -> None:
-        try:
-            raise FailedPostconditionError(
-                f"{self._exmsg_post} [Reason] {self._post_arg._error_message}"
-            )
-        except AttributeError:
-            raise FailedPostconditionError(self._exmsg_post)
+        self._raise_stage_postcondition_error()
 
     @abc.abstractmethod
     def _transform(
@@ -837,33 +859,41 @@ class PdPipelineStage(abc.ABC):
                 return X
             if y is not None:
                 y = self._cast_y_to_series(X, y)
-            if self._compound_prec(X, y, fit=True):
-                if verbose:
-                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                    print(msg, flush=True)
-                if self._is_an_Xy_fit_transformer:
-                    res_X, res_y = self._fit_transform_Xy(
-                        X, y, verbose=verbose
-                    )
-                elif self._is_an_Xy_transformer:
-                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-                else:
-                    res_X = self._fit_transform(X, verbose=verbose)
-                    res_y = y
-                self.is_fitted = True
-                if exraise and not self._compound_post(
-                    X=res_X, y=res_y, fit=True
-                ):
-                    self._raise_postcondition_error()
+            if not self._check_user_precondition(X=X, y=y, fit=True):
+                if exraise:
+                    self._raise_user_precondition_error()
                 if y is not None:
-                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                    return res_X, res_y
-                return res_X
-            if exraise:
-                self._raise_precondition_error()
+                    return X, y
+                return X
+            if not self._check_stage_precondition(X=X, y=y):
+                if exraise:
+                    self._raise_stage_precondition_error()
+                if y is not None:
+                    return X, y
+                return X
+            if verbose:
+                msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                print(msg, flush=True)
+            if self._is_an_Xy_fit_transformer:
+                res_X, res_y = self._fit_transform_Xy(X, y, verbose=verbose)
+            elif self._is_an_Xy_transformer:
+                res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
+            else:
+                res_X = self._fit_transform(X, verbose=verbose)
+                res_y = y
+            self.is_fitted = True
+            if exraise and not self._check_user_postcondition(
+                X=res_X, y=res_y, fit=True
+            ):
+                self._raise_user_postcondition_error()
+            if exraise and not self._check_stage_postcondition(
+                X=res_X, y=res_y
+            ):
+                self._raise_stage_postcondition_error()
             if y is not None:
-                return X, y
-            return X
+                res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                return res_X, res_y
+            return res_X
 
     def fit(self, X, y=None, exraise=None, verbose=False):
         """Fit this stage without transforming the given dataframe.
@@ -930,50 +960,64 @@ class PdPipelineStage(abc.ABC):
                 return X
             if y is not None:
                 y = self._cast_y_to_series(X, y)
-            if self._compound_prec(X, y):
-                if verbose:
-                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                    print(msg, flush=True)
-                if self._is_fittable():
-                    if self.is_fitted:
-                        if self._is_an_Xy_transformer:
-                            res_X, res_y = self._transform_Xy(
-                                X, y, verbose=verbose
-                            )
-                        else:
-                            res_X = self._transform(X, verbose=verbose)
-                            res_y = y
-                        if exraise and not self._compound_post(
-                            X=res_X, y=res_y
-                        ):
-                            self._raise_postcondition_error()
-                        if y is not None:
-                            res_X, res_y = self._align_Xy(
-                                X=res_X, y=res_y, preX=X
-                            )
-                            return res_X, res_y
-                        return res_X
-                    raise UnfittedPipelineStageError(
-                        "transform of an unfitted pipeline stage was called!"
-                    )
-                if self._is_an_Xy_transformer:
-                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-                else:
-                    res_X = self._transform(X, verbose=verbose)
-                    res_y = y
-                if exraise and not self._compound_post(X=res_X, y=res_y):
-                    self._raise_postcondition_error()
+            if not self._check_user_precondition(X=X, y=y):
+                if exraise:
+                    self._raise_user_precondition_error()
                 if y is not None:
-                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                    return res_X, res_y
-                return res_X
-            if exraise:
-                self._raise_precondition_error()
-            # precondition doesn't hold, but we don't want to raise an error
-            # as exraise is False, so return untransformed X or X, y
+                    return X, y
+                return X
+            if not self._check_stage_precondition(X=X, y=y):
+                if exraise:
+                    self._raise_stage_precondition_error()
+                if y is not None:
+                    return X, y
+                return X
+            if verbose:
+                msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                print(msg, flush=True)
+            if self._is_fittable():
+                if self.is_fitted:
+                    if self._is_an_Xy_transformer:
+                        res_X, res_y = self._transform_Xy(
+                            X, y, verbose=verbose
+                        )
+                    else:
+                        res_X = self._transform(X, verbose=verbose)
+                        res_y = y
+                    if exraise and not self._check_user_postcondition(
+                        X=res_X, y=res_y
+                    ):
+                        self._raise_user_postcondition_error()
+                    if exraise and not self._check_stage_postcondition(
+                        X=res_X, y=res_y
+                    ):
+                        self._raise_stage_postcondition_error()
+                    if y is not None:
+                        res_X, res_y = self._align_Xy(
+                            X=res_X, y=res_y, preX=X
+                        )
+                        return res_X, res_y
+                    return res_X
+                raise UnfittedPipelineStageError(
+                    "transform of an unfitted pipeline stage was called!"
+                )
+            if self._is_an_Xy_transformer:
+                res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
+            else:
+                res_X = self._transform(X, verbose=verbose)
+                res_y = y
+            if exraise and not self._check_user_postcondition(
+                X=res_X, y=res_y
+            ):
+                self._raise_user_postcondition_error()
+            if exraise and not self._check_stage_postcondition(
+                X=res_X, y=res_y
+            ):
+                self._raise_stage_postcondition_error()
             if y is not None:
-                return X, y
-            return X
+                res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                return res_X, res_y
+            return res_X
 
     def __add__(self, other):
         if isinstance(other, PdPipeline):

--- a/tests/core/test_issue_70.py
+++ b/tests/core/test_issue_70.py
@@ -1,0 +1,118 @@
+"""Test for issue #70: Incorrect precondition and postcondition error messages.
+
+This module tests that user-provided preconditions/postconditions are properly
+distinguished from stage preconditions/postconditions in error messages.
+
+"""
+
+import pandas as pd
+import pytest
+
+import pdpipe as pdp
+
+
+def _test_df_with_columns(columns):
+    """Helper to create test DataFrame with specified columns."""
+    return pd.DataFrame([[1, 4], [4, 5], [1, 11]], [1, 2, 3], columns)
+
+
+def test_user_precondition_error_message():
+    """Test that user precondition errors show appropriate messages."""
+    # Create test data - note that column 'x' does not exist
+    df = _test_df_with_columns(["a", "b"])
+
+    # Create pipeline with user precondition that will fail
+    pline = pdp.PdPipeline(
+        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["x"]))]
+    )
+
+    # Should raise FailedPreconditionError
+    with pytest.raises(Exception) as exc_info:
+        pline.apply(df)
+
+    error_msg = str(exc_info.value).lower()
+
+    # Check if error message indicates user precondition failure
+    assert (
+        "column x" in error_msg or "user-provided precondition" in error_msg
+    ), f"Expected user precondition error message, got: {exc_info.value}"
+
+
+def test_stage_precondition_error_message():
+    """Test that stage precondition errors still work correctly."""
+    # Create test data without column 'a' to trigger stage precondition failure
+    df = _test_df_with_columns(["x", "y"])
+
+    # Create pipeline without user precondition -
+    # should trigger stage precondition
+    pline = pdp.PdPipeline([pdp.FreqDrop(2, "a")])  # column 'a' missing
+
+    # Should raise FailedPreconditionError
+    with pytest.raises(Exception) as exc_info:
+        pline.apply(df)
+
+    error_msg = str(exc_info.value).lower()
+
+    # Check if this shows stage precondition error
+    assert (
+        "column a" in error_msg and "freqdrop" in error_msg
+    ), f"Expected stage precondition error message, got: {exc_info.value}"
+
+
+def test_successful_pipeline_execution():
+    """Test that normal operation still works with user preconditions."""
+    # Create test data where everything should work
+    df = _test_df_with_columns(["a", "b"])
+
+    # Create pipeline with user precondition that should pass
+    pline = pdp.PdPipeline(
+        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["a", "b"]))]
+    )
+
+    # Should not raise any exceptions
+    result = pline.apply(df)
+
+    # Basic sanity checks
+    assert result is not None
+    assert isinstance(result, pd.DataFrame)
+
+
+def test_user_vs_stage_precondition_distinction():
+    """Test that user and stage precondition failures are distinguishable.
+
+    This is the core test for issue #70 - ensuring that error messages
+    properly indicate whether a user-provided condition failed vs a stage's
+    built-in condition.
+
+    """
+    df = _test_df_with_columns(["a", "b"])
+
+    # Test 1: User precondition failure (column 'x' doesn't exist)
+    pline_user_fail = pdp.PdPipeline(
+        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["x"]))]
+    )
+
+    with pytest.raises(Exception) as user_exc:
+        pline_user_fail.apply(df)
+
+    # Test 2: Stage precondition failure
+    # (column 'z' doesn't exist for FreqDrop)
+    df_no_z = _test_df_with_columns(["a", "b"])
+    pline_stage_fail = pdp.PdPipeline([pdp.FreqDrop(2, "z")])
+
+    with pytest.raises(Exception) as stage_exc:
+        pline_stage_fail.apply(df_no_z)
+
+    # The error messages should be different
+    user_msg = str(user_exc.value).lower()
+    stage_msg = str(stage_exc.value).lower()
+
+    # User error should mention the missing column from user precondition
+    assert (
+        "column x" in user_msg or "user-provided precondition" in user_msg
+    ), f"User error should mention column 'x', got: {user_exc.value}"
+
+    # Stage error should mention the stage operation
+    asrt_msg = "Stage error should mention column 'z' and FreqDrop, "
+    asrt_msg += f"got: {stage_exc.value}"
+    assert "column z" in stage_msg and "freqdrop" in stage_msg, asrt_msg

--- a/tests/core/test_issue_70.py
+++ b/tests/core/test_issue_70.py
@@ -1,118 +1,103 @@
-"""Test for issue #70: Incorrect precondition and postcondition error messages.
-
-This module tests that user-provided preconditions/postconditions are properly
-distinguished from stage preconditions/postconditions in error messages.
-
-"""
+"""Regression tests for issue #70 condition error messages."""
 
 import pandas as pd
 import pytest
 
 import pdpipe as pdp
+from pdpipe.exceptions import (
+    FailedPostconditionError,
+    FailedPreconditionError,
+    PipelineApplicationError,
+)
 
 
-def _test_df_with_columns(columns):
-    """Helper to create test DataFrame with specified columns."""
-    return pd.DataFrame([[1, 4], [4, 5], [1, 11]], [1, 2, 3], columns)
+class _StageWithFailingPrecondition(pdp.PdPipelineStage):
+    """Stage with an always-failing built-in precondition."""
+
+    def __init__(self, **kwargs):
+        super().__init__(exmsg="Stage precondition marker", **kwargs)
+
+    def _prec(self, X):
+        return False
+
+    def _transform(self, X, verbose=False):
+        return X
+
+
+class _StageWithFailingPostcondition(pdp.PdPipelineStage):
+    """Stage with an always-failing built-in postcondition."""
+
+    def __init__(self, **kwargs):
+        super().__init__(exmsg="Stage precondition marker", **kwargs)
+
+    def _prec(self, X):
+        return True
+
+    def _post(self, X):
+        return False
+
+    def _transform(self, X, verbose=False):
+        return X
+
+
+def _test_df():
+    return pd.DataFrame(
+        [[1, 4], [4, 5], [1, 11]],
+        [1, 2, 3],
+        ["a", "b"],
+    )
+
+
+def _pipeline_cause(stage, df):
+    pline = pdp.PdPipeline([stage])
+    with pytest.raises(PipelineApplicationError) as exc_info:
+        pline.apply(df)
+    return exc_info.value.__cause__
 
 
 def test_user_precondition_error_message():
-    """Test that user precondition errors show appropriate messages."""
-    # Create test data - note that column 'x' does not exist
-    df = _test_df_with_columns(["a", "b"])
-
-    # Create pipeline with user precondition that will fail
-    pline = pdp.PdPipeline(
-        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["x"]))]
+    cause = _pipeline_cause(
+        stage=_StageWithFailingPrecondition(
+            prec=pdp.cond.HasAllColumns(["x"]),
+        ),
+        df=_test_df(),
     )
-
-    # Should raise FailedPreconditionError
-    with pytest.raises(Exception) as exc_info:
-        pline.apply(df)
-
-    error_msg = str(exc_info.value).lower()
-
-    # Check if error message indicates user precondition failure
-    assert (
-        "column x" in error_msg or "user-provided precondition" in error_msg
-    ), f"Expected user precondition error message, got: {exc_info.value}"
+    assert isinstance(cause, FailedPreconditionError)
+    message = str(cause)
+    assert "Not all required columns x" in message
+    assert "Stage precondition marker" not in message
 
 
 def test_stage_precondition_error_message():
-    """Test that stage precondition errors still work correctly."""
-    # Create test data without column 'a' to trigger stage precondition failure
-    df = _test_df_with_columns(["x", "y"])
-
-    # Create pipeline without user precondition -
-    # should trigger stage precondition
-    pline = pdp.PdPipeline([pdp.FreqDrop(2, "a")])  # column 'a' missing
-
-    # Should raise FailedPreconditionError
-    with pytest.raises(Exception) as exc_info:
-        pline.apply(df)
-
-    error_msg = str(exc_info.value).lower()
-
-    # Check if this shows stage precondition error
-    assert (
-        "column a" in error_msg and "freqdrop" in error_msg
-    ), f"Expected stage precondition error message, got: {exc_info.value}"
-
-
-def test_successful_pipeline_execution():
-    """Test that normal operation still works with user preconditions."""
-    # Create test data where everything should work
-    df = _test_df_with_columns(["a", "b"])
-
-    # Create pipeline with user precondition that should pass
-    pline = pdp.PdPipeline(
-        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["a", "b"]))]
+    cause = _pipeline_cause(
+        stage=_StageWithFailingPrecondition(
+            prec=pdp.cond.HasAllColumns(["a"]),
+        ),
+        df=_test_df(),
     )
-
-    # Should not raise any exceptions
-    result = pline.apply(df)
-
-    # Basic sanity checks
-    assert result is not None
-    assert isinstance(result, pd.DataFrame)
+    assert isinstance(cause, FailedPreconditionError)
+    assert str(cause) == "Stage precondition marker"
 
 
-def test_user_vs_stage_precondition_distinction():
-    """Test that user and stage precondition failures are distinguishable.
-
-    This is the core test for issue #70 - ensuring that error messages
-    properly indicate whether a user-provided condition failed vs a stage's
-    built-in condition.
-
-    """
-    df = _test_df_with_columns(["a", "b"])
-
-    # Test 1: User precondition failure (column 'x' doesn't exist)
-    pline_user_fail = pdp.PdPipeline(
-        [pdp.FreqDrop(2, "a", prec=pdp.cond.HasAllColumns(["x"]))]
+def test_user_postcondition_error_message():
+    cause = _pipeline_cause(
+        stage=_StageWithFailingPostcondition(
+            post=pdp.cond.HasAllColumns(["x"]),
+        ),
+        df=_test_df(),
     )
+    assert isinstance(cause, FailedPostconditionError)
+    message = str(cause)
+    assert "Not all required columns x" in message
+    assert "Stage postcondition marker" not in message
 
-    with pytest.raises(Exception) as user_exc:
-        pline_user_fail.apply(df)
 
-    # Test 2: Stage precondition failure
-    # (column 'z' doesn't exist for FreqDrop)
-    df_no_z = _test_df_with_columns(["a", "b"])
-    pline_stage_fail = pdp.PdPipeline([pdp.FreqDrop(2, "z")])
-
-    with pytest.raises(Exception) as stage_exc:
-        pline_stage_fail.apply(df_no_z)
-
-    # The error messages should be different
-    user_msg = str(user_exc.value).lower()
-    stage_msg = str(stage_exc.value).lower()
-
-    # User error should mention the missing column from user precondition
-    assert (
-        "column x" in user_msg or "user-provided precondition" in user_msg
-    ), f"User error should mention column 'x', got: {user_exc.value}"
-
-    # Stage error should mention the stage operation
-    asrt_msg = "Stage error should mention column 'z' and FreqDrop, "
-    asrt_msg += f"got: {stage_exc.value}"
-    assert "column z" in stage_msg and "freqdrop" in stage_msg, asrt_msg
+def test_stage_postcondition_error_message():
+    cause = _pipeline_cause(
+        stage=_StageWithFailingPostcondition(
+            post=pdp.cond.HasAllColumns(["a"]),
+        ),
+        df=_test_df(),
+    )
+    assert isinstance(cause, FailedPostconditionError)
+    assert str(cause) == "Stage postcondition marker"

--- a/tests/core/test_pipeline_stage.py
+++ b/tests/core/test_pipeline_stage.py
@@ -293,7 +293,7 @@ def test_failing_postcond():
 
 def test_prec_condition_error_message():
     stage = SomeStage(prec=Condition(_no_a_in_cols))
-    generic_err = "Precondition failed .*"
+    generic_err = "User-provided precondition failed."
     with pytest.raises(FailedPreconditionError, match=generic_err):
         stage(_test_df2())
 
@@ -301,14 +301,14 @@ def test_prec_condition_error_message():
     stage = SomeStage(
         prec=Condition(_no_a_in_cols, error_message=error_message)
     )
-    specific_err = "Precondition failed .* " + error_message
+    specific_err = error_message
     with pytest.raises(FailedPreconditionError, match=specific_err):
         stage(_test_df2())
 
 
 def test_post_condition_error_message():
     stage = SomeStage(post=Condition(_no_a_in_cols))
-    generic_err = "Postcondition failed .*"
+    generic_err = "User-provided postcondition failed."
     with pytest.raises(FailedPostconditionError, match=generic_err):
         stage(_test_df2())
 
@@ -316,6 +316,6 @@ def test_post_condition_error_message():
     stage = SomeStage(
         post=Condition(_no_a_in_cols, error_message=error_message)
     )
-    specific_err = "Postcondition failed .* " + error_message
+    specific_err = error_message
     with pytest.raises(FailedPostconditionError, match=specific_err):
         stage(_test_df2())

--- a/tests/core/test_pipeline_stage.py
+++ b/tests/core/test_pipeline_stage.py
@@ -219,6 +219,39 @@ class FittableDropByCharStage(PdPipelineStage):
         return df[keep_cols]
 
 
+class PrecNeedsYStage(PdPipelineStage):
+    """A stage whose precondition requires the y argument."""
+
+    def _prec(self, df, y):  # noqa: W0613
+        return True
+
+    def _transform(self, df, verbose):
+        return df
+
+
+class PrecXOnlyStage(PdPipelineStage):
+    """A stage whose precondition accepts only X."""
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        return df
+
+
+class PostXOnlyStage(PdPipelineStage):
+    """A stage whose postcondition accepts only X."""
+
+    def _prec(self, df):
+        return True
+
+    def _post(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        return df
+
+
 def _test_df2():
     return pd.DataFrame(
         data=[[1, "a"], [2, "b"]], index=[1, 2], columns=["abo", "coo"]
@@ -319,3 +352,38 @@ def test_post_condition_error_message():
     specific_err = error_message
     with pytest.raises(FailedPostconditionError, match=specific_err):
         stage(_test_df2())
+
+
+def test_compound_prec_fallback_when_stage_prec_requires_y():
+    stage = PrecNeedsYStage()
+    assert stage._compound_prec(_test_df2(), y=None)
+
+
+def test_compound_prec_fallback_when_stage_prec_accepts_only_x():
+    stage = PrecXOnlyStage()
+    y = pd.Series([0, 1], index=_test_df2().index)
+    assert stage._compound_prec(_test_df2(), y=y)
+
+
+def test_compound_post_fallback_when_stage_post_accepts_only_x():
+    stage = PostXOnlyStage()
+    y = pd.Series([0, 1], index=_test_df2().index)
+    assert stage._compound_post(_test_df2(), y=y)
+
+
+def test_user_prec_typeerror_is_re_raised():
+    def bad_prec(X, y):  # noqa: W0613
+        raise TypeError("bad user precondition")
+
+    stage = SomeStage(prec=bad_prec)
+    with pytest.raises(TypeError, match="bad user precondition"):
+        stage._compound_prec(_test_df2(), y=None)
+
+
+def test_user_post_typeerror_is_re_raised():
+    def bad_post(X, y):  # noqa: W0613
+        raise TypeError("bad user postcondition")
+
+    stage = SomeStage(post=bad_post)
+    with pytest.raises(TypeError, match="bad user postcondition"):
+        stage._compound_post(_test_df2(), y=None)

--- a/tests/core/test_pipeline_stage.py
+++ b/tests/core/test_pipeline_stage.py
@@ -1,6 +1,7 @@
 """Testing basic pipeline stages."""
 
 import pickle
+import re
 
 import pandas as pd
 import pytest
@@ -326,7 +327,7 @@ def test_failing_postcond():
 
 def test_prec_condition_error_message():
     stage = SomeStage(prec=Condition(_no_a_in_cols))
-    generic_err = "User-provided precondition failed."
+    generic_err = re.escape("User-provided precondition failed.")
     with pytest.raises(FailedPreconditionError, match=generic_err):
         stage(_test_df2())
 
@@ -341,7 +342,7 @@ def test_prec_condition_error_message():
 
 def test_post_condition_error_message():
     stage = SomeStage(post=Condition(_no_a_in_cols))
-    generic_err = "User-provided postcondition failed."
+    generic_err = re.escape("User-provided postcondition failed.")
     with pytest.raises(FailedPostconditionError, match=generic_err):
         stage(_test_df2())
 


### PR DESCRIPTION
Fixes #70.

This PR now includes:
- src/pdpipe/core.py
  - Distinguish user-provided vs stage-provided pre/post condition failures.
  - Surface user condition _error_message directly for user condition failures.
  - Keep stage exmsg/exmsg_post for stage condition failures.
  - Reword default exmsg semantics to stage-application failure wording.
- tests/core/test_issue_70.py
  - Regression tests for both precondition and postcondition message attribution via PipelineApplicationError.__cause__.
- tests/core/test_pipeline_stage.py
  - Updated message expectation tests.
  - Added fallback branch tests for _compound_prec/_compound_post signature compatibility and re-raise paths.

Follow-up (low priority): #148
