### PR TITLE
Add dependency-free pipeline DOT export

### DIFF
--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -1956,14 +1956,19 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
     def _dot_stage_label(index, stage):
         desc = stage.description()
         name = getattr(stage, "_name", "")
-        stage_label = f"{name}: {desc}" if name else desc
-        return PdPipeline._dot_escape(f"[{index}] {stage_label}")
+        class_name = stage.__class__.__name__
+        if name:
+            stage_label = f"[{index}] {class_name}: {name}\n{desc}"
+        else:
+            stage_label = f"[{index}] {class_name}\n{desc}"
+        return PdPipeline._dot_escape(stage_label)
 
     def to_dot(self):
         """Return a Graphviz DOT representation of this pipeline.
 
         The returned graph is dependency-free text with deterministic node IDs
-        based on stage order.
+        based on stage order. Node labels include each stage's index, class
+        name, optional stage name and description.
 
         Returns
         -------

--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -1942,6 +1942,48 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
             return PdPipeline([*self._stages, other])
         return NotImplemented
 
+    @staticmethod
+    def _dot_escape(value):
+        return (
+            str(value)
+            .replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+        )
+
+    @staticmethod
+    def _dot_stage_label(index, stage):
+        desc = stage.description()
+        name = getattr(stage, "_name", "")
+        stage_label = f"{name}: {desc}" if name else desc
+        return PdPipeline._dot_escape(f"[{index}] {stage_label}")
+
+    def to_dot(self):
+        """Return a Graphviz DOT representation of this pipeline.
+
+        The returned graph is dependency-free text with deterministic node IDs
+        based on stage order.
+
+        Returns
+        -------
+        str
+            A Graphviz DOT representation of this pipeline.
+
+        """
+        lines = [
+            "digraph PdPipeline {",
+            "  graph [rankdir=LR];",
+            "  node [shape=box];",
+        ]
+        for index, stage in enumerate(self._stages):
+            label = self._dot_stage_label(index, stage)
+            lines.append(f'  stage_{index} [label="{label}"];')
+        for index in range(len(self._stages) - 1):
+            lines.append(f"  stage_{index} -> stage_{index + 1};")
+        lines.append("}")
+        return "\n".join(lines)
+
     def __times_str__(self, times):
         res = "A pdpipe pipeline:\n"
         stime = sum(times)

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -180,8 +180,11 @@ def test_pipeline_to_dot_represents_stage_order_and_names():
             "digraph PdPipeline {",
             "  graph [rankdir=LR];",
             "  node [shape=box];",
-            '  stage_0 [label="[0] drop_num1: Drop num1 column"];',
-            '  stage_1 [label="[1] Drop num2 column"];',
+            (
+                '  stage_0 [label="[0] SilentDropStage: '
+                'drop_num1\\nDrop num1 column"];'
+            ),
+            '  stage_1 [label="[1] SilentDropStage\\nDrop num2 column"];',
             "  stage_0 -> stage_1;",
             "}",
         ]
@@ -203,7 +206,7 @@ def test_pipeline_to_dot_escapes_dot_label_characters():
             "  graph [rankdir=LR];",
             "  node [shape=box];",
             (
-                '  stage_0 [label="[0] drop \\"quoted\\": '
+                '  stage_0 [label="[0] SilentDropStage: drop \\"quoted\\"\\n'
                 'Drop \\"quoted\\" \\\\ column\\nthen continue"];'
             ),
             "}",

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -165,6 +165,78 @@ def test_pipeline_to_int_addition():
         assert not isinstance(res, PdPipeline)
 
 
+def test_pipeline_to_dot_represents_stage_order_and_names():
+    """Test pipeline DOT export uses stable ordered nodes."""
+    drop_num1 = SilentDropStage(
+        "num1",
+        name="drop_num1",
+        desc="Drop num1 column",
+    )
+    drop_num2 = SilentDropStage("num2", desc="Drop num2 column")
+    pipeline = PdPipeline([drop_num1, drop_num2])
+
+    assert pipeline.to_dot() == "\n".join(
+        [
+            "digraph PdPipeline {",
+            "  graph [rankdir=LR];",
+            "  node [shape=box];",
+            '  stage_0 [label="[0] drop_num1: Drop num1 column"];',
+            '  stage_1 [label="[1] Drop num2 column"];',
+            "  stage_0 -> stage_1;",
+            "}",
+        ]
+    )
+
+
+def test_pipeline_to_dot_escapes_dot_label_characters():
+    """Test pipeline DOT export escapes label text."""
+    stage = SilentDropStage(
+        "num1",
+        name='drop "quoted"',
+        desc='Drop "quoted" \\ column\nthen continue',
+    )
+    pipeline = PdPipeline([stage])
+
+    assert pipeline.to_dot() == "\n".join(
+        [
+            "digraph PdPipeline {",
+            "  graph [rankdir=LR];",
+            "  node [shape=box];",
+            (
+                '  stage_0 [label="[0] drop \\"quoted\\": '
+                'Drop \\"quoted\\" \\\\ column\\nthen continue"];'
+            ),
+            "}",
+        ]
+    )
+
+
+def test_pipeline_to_dot_is_deterministic_across_calls():
+    """Test pipeline DOT export is deterministic."""
+    pipeline = PdPipeline(
+        [
+            SilentDropStage("num1", desc="Drop num1 column"),
+            SilentDropStage("num2", desc="Drop num2 column"),
+        ]
+    )
+
+    assert pipeline.to_dot() == pipeline.to_dot()
+
+
+def test_empty_pipeline_to_dot():
+    """Test DOT export for empty pipelines."""
+    pipeline = PdPipeline([])
+
+    assert pipeline.to_dot() == "\n".join(
+        [
+            "digraph PdPipeline {",
+            "  graph [rankdir=LR];",
+            "  node [shape=box];",
+            "}",
+        ]
+    )
+
+
 def test_pipeline_index():
     """Testing something."""
     df = _test_df()


### PR DESCRIPTION
## Summary

Adds `PdPipeline.to_dot()` as a dependency-free global pipeline visualization/export API.

The method returns deterministic Graphviz DOT text for the pipeline structure:

- stages are represented in their pipeline order
- node IDs are stable index-based IDs (`stage_0`, `stage_1`, ...), independent of object memory addresses
- node labels include the stage index, stage class, optional stage name, and existing stage description
- DOT label-sensitive characters are escaped for stable rendering
- empty pipelines produce a valid empty DOT graph

Refs #158.

## Scope

This is the first, narrow slice of issue #158. It intentionally does not add local dataframe explanations, dry-run debugging, Graphviz rendering dependencies, or a broader visualization architecture. Those remain follow-up work if the project wants them.

## API choice

The public method is named `to_dot()` because this change exports DOT text directly and mirrors common object-to-format naming while keeping the implementation dependency-free. It avoids adding a rendering abstraction or optional Graphviz integration in this first slice.

## Review follow-up

A self-review pass tightened the DOT node label contract so nodes include stage class names, making graphs more useful when descriptions repeat or stages are unnamed. The escaping regression was updated for the final multiline class/name/description format.

## Validation

- `.venv/bin/python -m pytest tests/core/test_pipeline.py -q` - 17 passed
- `.venv/bin/python -m black src/pdpipe/core.py tests/core/test_pipeline.py` - no changes
- `.venv/bin/python -m flake8 src/pdpipe/core.py tests/core/test_pipeline.py` - passed
- `.venv/bin/python -m black --check .` - passed before review follow-up, `109 files would be left unchanged`

Note: full `python -m flake8` in this shell is noisy because this invocation scans `.venv` and `build/`; the touched-file flake8 run is clean.
