### PR TITLE
Add pipeline trace dry-run API

### DIFF
--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -2027,6 +2027,68 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
         trace_entry["error_type"] = error.__class__.__name__
         trace_entry["error_message"] = str(error)
 
+    @staticmethod
+    def _trace_stage_exraise(stage, exraise):
+        return stage._exraise if exraise is None else exraise
+
+    @staticmethod
+    def _trace_apply_stage(stage, X, y, fit, exraise, verbose):
+        stage_exraise = PdPipeline._trace_stage_exraise(stage, exraise)
+        with AppContextMgr(stage, fit=fit):
+            if stage._should_skip(X, y):
+                return "skipped", "skip", X, y
+            if y is not None:
+                y = stage._cast_y_to_series(X, y)
+            if not stage._compound_prec(X, y, fit=fit):
+                if stage_exraise:
+                    stage._raise_precondition_error()
+                return "skipped", "precondition", X, y
+            if verbose:
+                msg = "- " + "\n  ".join(textwrap.wrap(stage._appmsg))
+                print(msg, flush=True)
+            if fit:
+                if stage._is_an_Xy_fit_transformer:
+                    res_X, res_y = stage._fit_transform_Xy(
+                        X, y, verbose=verbose
+                    )
+                elif stage._is_an_Xy_transformer:
+                    res_X, res_y = stage._transform_Xy(X, y, verbose=verbose)
+                else:
+                    res_X = stage._fit_transform(X, verbose=verbose)
+                    res_y = y
+                stage.is_fitted = True
+                if stage_exraise and not stage._compound_post(
+                    X=res_X, y=res_y, fit=True
+                ):
+                    stage._raise_postcondition_error()
+            else:
+                if stage._is_fittable():
+                    if not stage.is_fitted:
+                        raise UnfittedPipelineStageError(
+                            "transform of an unfitted pipeline stage was "
+                            "called!"
+                        )
+                    if stage._is_an_Xy_transformer:
+                        res_X, res_y = stage._transform_Xy(
+                            X, y, verbose=verbose
+                        )
+                    else:
+                        res_X = stage._transform(X, verbose=verbose)
+                        res_y = y
+                elif stage._is_an_Xy_transformer:
+                    res_X, res_y = stage._transform_Xy(X, y, verbose=verbose)
+                else:
+                    res_X = stage._transform(X, verbose=verbose)
+                    res_y = y
+                if stage_exraise and not stage._compound_post(
+                    X=res_X, y=res_y
+                ):
+                    stage._raise_postcondition_error()
+            if y is not None:
+                res_X, res_y = stage._align_Xy(X=res_X, y=res_y, preX=X)
+                return "applied", None, res_X, res_y
+            return "applied", None, res_X, res_y
+
     def trace(
         self,
         X: pandas.DataFrame,
@@ -2099,45 +2161,21 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
 
             try:
                 traced_pipeline._use_dynamics(stage, inter_X, inter_y)
-                if stage._should_skip(inter_X, inter_y):
-                    trace_entry["status"] = "skipped"
-                    trace_entry["skip_reason"] = "skip"
-                    self._trace_set_output(trace_entry, inter_X)
-                    continue
-
-                if inter_y is not None:
-                    inter_y = stage._cast_y_to_series(inter_X, inter_y)
-
-                if not stage._compound_prec(inter_X, inter_y, fit=fit):
-                    stage_exraise = (
-                        stage._exraise if exraise is None else exraise
-                    )
-                    if stage_exraise:
-                        stage._raise_precondition_error()
-                    trace_entry["status"] = "skipped"
-                    trace_entry["skip_reason"] = "precondition"
-                    self._trace_set_output(trace_entry, inter_X)
-                    continue
-
-                if fit:
-                    result = stage.fit_transform(
-                        X=inter_X,
-                        y=inter_y,
-                        exraise=exraise,
-                        verbose=verbose,
-                    )
-                else:
-                    result = stage.transform(
-                        X=inter_X,
-                        y=inter_y,
-                        exraise=exraise,
-                        verbose=verbose,
-                    )
-                if inter_y is None:
-                    inter_X = result
-                else:
-                    inter_X, inter_y = result
-                trace_entry["status"] = "applied"
+                (
+                    status,
+                    skip_reason,
+                    inter_X,
+                    inter_y,
+                ) = self._trace_apply_stage(
+                    stage=stage,
+                    X=inter_X,
+                    y=inter_y,
+                    fit=fit,
+                    exraise=exraise,
+                    verbose=verbose,
+                )
+                trace_entry["status"] = status
+                trace_entry["skip_reason"] = skip_reason
                 self._trace_set_output(trace_entry, inter_X)
             except Exception as error:  # pylint: disable=broad-except
                 self._trace_set_error(trace_entry, error)

--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -2,6 +2,7 @@
 
 import abc
 import collections
+import copy
 import inspect
 import re
 import sys
@@ -1988,6 +1989,163 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
             lines.append(f"  stage_{index} -> stage_{index + 1};")
         lines.append("}")
         return "\n".join(lines)
+
+    @staticmethod
+    def _trace_frame_state(frame):
+        return {
+            "shape": frame.shape,
+            "columns": list(frame.columns),
+        }
+
+    @staticmethod
+    def _trace_stage_base(index, stage, input_frame):
+        input_state = PdPipeline._trace_frame_state(input_frame)
+        return {
+            "stage_index": index,
+            "stage_class": stage.__class__.__name__,
+            "stage_name": getattr(stage, "_name", ""),
+            "stage_description": stage.description(),
+            "status": None,
+            "skip_reason": None,
+            "input_shape": input_state["shape"],
+            "input_columns": input_state["columns"],
+            "output_shape": None,
+            "output_columns": None,
+            "error_type": None,
+            "error_message": None,
+        }
+
+    @staticmethod
+    def _trace_set_output(trace_entry, output_frame):
+        output_state = PdPipeline._trace_frame_state(output_frame)
+        trace_entry["output_shape"] = output_state["shape"]
+        trace_entry["output_columns"] = output_state["columns"]
+
+    @staticmethod
+    def _trace_set_error(trace_entry, error):
+        trace_entry["status"] = "failed"
+        trace_entry["error_type"] = error.__class__.__name__
+        trace_entry["error_message"] = str(error)
+
+    def trace(
+        self,
+        X: pandas.DataFrame,
+        y: Optional[Iterable] = None,
+        exraise: Optional[bool] = False,
+        verbose: Optional[bool] = False,
+        fit_context: Optional[dict] = None,
+        application_context: Optional[dict] = None,
+    ):
+        """Trace applying this pipeline to a dataframe.
+
+        This method is a dependency-free dry-run helper for inspecting how a
+        pipeline applies to a specific dataframe. It returns a list of
+        dictionaries, one per visited stage, with stage metadata, status,
+        input/output dataframe shape, and input/output column labels.
+
+        Tracing runs on a deep copy of the pipeline and on a deep copy of the
+        input dataframe. If this pipeline is already fitted, the copied
+        pipeline is transformed. Otherwise, the copied pipeline is
+        fit-transformed. In both cases, the original pipeline and input
+        dataframe are left unmodified by tracing.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame
+            The dataframe to trace through this pipeline.
+        y : array-like, optional
+            Targets for supervised learning.
+        exraise : bool, default False
+            Determines behaviour if the precondition of a composing stage is
+            not fulfilled by the input dataframe. If True, failed
+            preconditions are reported as failed trace entries. If False, they
+            are reported as skipped trace entries. If None, each stage's
+            configured exraise behaviour is used.
+        verbose : bool, default False
+            If True, stage application messages may be printed while tracing.
+        fit_context : dict, optional
+            Context for the copied pipeline fit operation. Only used when this
+            pipeline is not fitted.
+        application_context : dict, optional
+            Context to add to the copied pipeline application context.
+
+        Returns
+        -------
+        list of dict
+            Structured per-stage trace records.
+
+        """
+        fit_context = {} if fit_context is None else fit_context
+        application_context = (
+            {} if application_context is None else application_context
+        )
+        traced_pipeline = copy.deepcopy(self)
+        trace = []
+        inter_X = copy.deepcopy(X)
+        inter_y = copy.deepcopy(y)
+        fit = not traced_pipeline.is_fitted
+
+        traced_pipeline.application_context = PdpApplicationContext()
+        traced_pipeline.application_context.update(application_context)
+        if fit:
+            traced_pipeline.fit_context = PdpApplicationContext()
+            traced_pipeline.fit_context.update(fit_context)
+
+        for index, stage in enumerate(traced_pipeline._stages):
+            trace_entry = self._trace_stage_base(index, stage, inter_X)
+            trace.append(trace_entry)
+            stage.fit_context = traced_pipeline.fit_context
+            stage.application_context = traced_pipeline.application_context
+
+            try:
+                traced_pipeline._use_dynamics(stage, inter_X, inter_y)
+                if stage._should_skip(inter_X, inter_y):
+                    trace_entry["status"] = "skipped"
+                    trace_entry["skip_reason"] = "skip"
+                    self._trace_set_output(trace_entry, inter_X)
+                    continue
+
+                if inter_y is not None:
+                    inter_y = stage._cast_y_to_series(inter_X, inter_y)
+
+                if not stage._compound_prec(inter_X, inter_y, fit=fit):
+                    stage_exraise = (
+                        stage._exraise if exraise is None else exraise
+                    )
+                    if stage_exraise:
+                        stage._raise_precondition_error()
+                    trace_entry["status"] = "skipped"
+                    trace_entry["skip_reason"] = "precondition"
+                    self._trace_set_output(trace_entry, inter_X)
+                    continue
+
+                if fit:
+                    result = stage.fit_transform(
+                        X=inter_X,
+                        y=inter_y,
+                        exraise=exraise,
+                        verbose=verbose,
+                    )
+                else:
+                    result = stage.transform(
+                        X=inter_X,
+                        y=inter_y,
+                        exraise=exraise,
+                        verbose=verbose,
+                    )
+                if inter_y is None:
+                    inter_X = result
+                else:
+                    inter_X, inter_y = result
+                trace_entry["status"] = "applied"
+                self._trace_set_output(trace_entry, inter_X)
+            except Exception as error:  # pylint: disable=broad-except
+                self._trace_set_error(trace_entry, error)
+                break
+            finally:
+                stage.application_context = None
+
+        return trace
 
     def __times_str__(self, times):
         res = "A pdpipe pipeline:\n"

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -67,6 +67,19 @@ class FittableMarkingStage(PdPipelineStage):
         return df.drop(["num1"], axis=1)
 
 
+class XyTraceStage(PdPipelineStage):
+    """A dataframe and label transformer for trace tests."""
+
+    def _prec(self, df, y):
+        return True
+
+    def _transform(self, df, verbose):
+        return df
+
+    def _transform_Xy(self, df, y, verbose):
+        return df.drop(["num1"], axis=1), y
+
+
 @pytest.mark.parametrize("time", [True, False])
 def test_two_stage_pipeline_stage(time):
     """Testing something."""
@@ -361,6 +374,19 @@ def test_pipeline_trace_reports_failure_and_stops():
     assert trace[1]["error_message"] == "trace failure"
 
 
+def test_pipeline_trace_can_report_precondition_failure():
+    """Test exraise=True reports unmet preconditions as failures."""
+    pipeline = PdPipeline([SilentDropStage("missing")])
+
+    trace = pipeline.trace(_test_df(), exraise=True)
+
+    assert trace[0]["status"] == "failed"
+    assert trace[0]["skip_reason"] is None
+    assert trace[0]["output_shape"] is None
+    assert trace[0]["output_columns"] is None
+    assert trace[0]["error_type"] == "FailedPreconditionError"
+
+
 def test_pipeline_trace_is_deterministic_across_calls():
     """Test trace output order and content are deterministic."""
     pipeline = PdPipeline(
@@ -403,6 +429,35 @@ def test_pipeline_trace_does_not_mutate_input_dataframe_or_pipeline_state():
     assert trace[1]["status"] == "applied"
     assert trace[1]["input_columns"] == ["num2", "char"]
     assert trace[1]["output_columns"] == ["num2", "char", "mutated"]
+
+
+def test_pipeline_trace_uses_transform_for_fitted_pipelines():
+    """Test trace uses transform semantics for fitted pipelines."""
+    pipeline = PdPipeline([SilentDropStage("num1")])
+    df = _test_df()
+    pipeline.fit(df)
+
+    trace = pipeline.trace(df)
+
+    assert pipeline.is_fitted
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["input_columns"] == ["num1", "num2", "char"]
+    assert trace[0]["output_columns"] == ["num2", "char"]
+
+
+def test_pipeline_trace_supports_label_transforming_stages():
+    """Test trace handles stages that transform both X and y."""
+    pipeline = PdPipeline([XyTraceStage()])
+    df = _test_df()
+    y = pd.Series(["a", "b"], index=df.index)
+
+    trace = pipeline.trace(df, y=y)
+
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["input_shape"] == (2, 3)
+    assert trace[0]["input_columns"] == ["num1", "num2", "char"]
+    assert trace[0]["output_shape"] == (2, 2)
+    assert trace[0]["output_columns"] == ["num2", "char"]
 
 
 def test_pipeline_index():

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -350,6 +350,33 @@ def test_pipeline_trace_reports_skip_callable_stages():
     assert trace[0]["output_columns"] == ["num1", "num2", "char"]
 
 
+def test_pipeline_trace_evaluates_stage_conditions_once():
+    """Test trace does not double-call user conditions."""
+    calls = []
+
+    class CountingConditionStage(PdPipelineStage):
+        """A pipeline stage with observable condition calls."""
+
+        def _prec(self, df):
+            calls.append("precondition")
+            return True
+
+        def _transform(self, df, verbose):
+            return df.drop(["num1"], axis=1)
+
+    def skip(df):
+        calls.append("skip")
+        return False
+
+    pipeline = PdPipeline([CountingConditionStage(skip=skip)])
+
+    trace = pipeline.trace(_test_df())
+
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["output_columns"] == ["num2", "char"]
+    assert calls == ["skip", "precondition"]
+
+
 def test_pipeline_trace_reports_failure_and_stops():
     """Test trace records a failing stage and stops at the failure."""
     pipeline = PdPipeline(

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -32,6 +32,41 @@ class SilentDropStage(PdPipelineStage):
         return df.drop([self.colname], axis=1)
 
 
+class FailingTransformStage(PdPipelineStage):
+    """A pipeline stage that fails during transformation."""
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        raise ValueError("trace failure")
+
+
+class MutatingStage(PdPipelineStage):
+    """A pipeline stage that mutates its input dataframe."""
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        df["mutated"] = 1
+        return df
+
+
+class FittableMarkingStage(PdPipelineStage):
+    """A fittable pipeline stage for trace isolation tests."""
+
+    def _prec(self, df):
+        return True
+
+    def _fit_transform(self, df, verbose):
+        self.was_fitted = True
+        return df.drop(["num1"], axis=1)
+
+    def _transform(self, df, verbose):
+        return df.drop(["num1"], axis=1)
+
+
 @pytest.mark.parametrize("time", [True, False])
 def test_two_stage_pipeline_stage(time):
     """Testing something."""
@@ -238,6 +273,136 @@ def test_empty_pipeline_to_dot():
             "}",
         ]
     )
+
+
+def test_pipeline_trace_reports_applied_and_precondition_skipped_stages():
+    """Test structured trace records for applied and precondition skips."""
+    drop_num1 = SilentDropStage(
+        "num1",
+        name="drop_num1",
+        desc="Drop num1 column",
+    )
+    missing = SilentDropStage("missing", desc="Drop missing column")
+    pipeline = PdPipeline([drop_num1, missing])
+    df = _test_df()
+
+    trace = pipeline.trace(df)
+
+    assert trace == [
+        {
+            "stage_index": 0,
+            "stage_class": "SilentDropStage",
+            "stage_name": "drop_num1",
+            "stage_description": "Drop num1 column",
+            "status": "applied",
+            "skip_reason": None,
+            "input_shape": (2, 3),
+            "input_columns": ["num1", "num2", "char"],
+            "output_shape": (2, 2),
+            "output_columns": ["num2", "char"],
+            "error_type": None,
+            "error_message": None,
+        },
+        {
+            "stage_index": 1,
+            "stage_class": "SilentDropStage",
+            "stage_name": "",
+            "stage_description": "Drop missing column",
+            "status": "skipped",
+            "skip_reason": "precondition",
+            "input_shape": (2, 2),
+            "input_columns": ["num2", "char"],
+            "output_shape": (2, 2),
+            "output_columns": ["num2", "char"],
+            "error_type": None,
+            "error_message": None,
+        },
+    ]
+
+
+def test_pipeline_trace_reports_skip_callable_stages():
+    """Test trace distinguishes skip callbacks from precondition skips."""
+    stage = SilentDropStage(
+        "num1",
+        skip=lambda df: True,
+        desc="Conditionally drop num1",
+    )
+    pipeline = PdPipeline([stage])
+
+    trace = pipeline.trace(_test_df())
+
+    assert trace[0]["status"] == "skipped"
+    assert trace[0]["skip_reason"] == "skip"
+    assert trace[0]["input_columns"] == ["num1", "num2", "char"]
+    assert trace[0]["output_columns"] == ["num1", "num2", "char"]
+
+
+def test_pipeline_trace_reports_failure_and_stops():
+    """Test trace records a failing stage and stops at the failure."""
+    pipeline = PdPipeline(
+        [
+            SilentDropStage("num1"),
+            FailingTransformStage(desc="Fail in transform"),
+            SilentDropStage("char"),
+        ]
+    )
+
+    trace = pipeline.trace(_test_df())
+
+    assert [entry["status"] for entry in trace] == ["applied", "failed"]
+    assert trace[1]["stage_index"] == 1
+    assert trace[1]["stage_class"] == "FailingTransformStage"
+    assert trace[1]["stage_description"] == "Fail in transform"
+    assert trace[1]["input_shape"] == (2, 2)
+    assert trace[1]["input_columns"] == ["num2", "char"]
+    assert trace[1]["output_shape"] is None
+    assert trace[1]["output_columns"] is None
+    assert trace[1]["error_type"] == "ValueError"
+    assert trace[1]["error_message"] == "trace failure"
+
+
+def test_pipeline_trace_is_deterministic_across_calls():
+    """Test trace output order and content are deterministic."""
+    pipeline = PdPipeline(
+        [
+            SilentDropStage("num1", name="first"),
+            SilentDropStage("num2", name="second"),
+            SilentDropStage("char", name="third"),
+        ]
+    )
+    df = _test_df()
+
+    first_trace = pipeline.trace(df)
+    second_trace = pipeline.trace(df)
+
+    assert first_trace == second_trace
+    assert [entry["stage_index"] for entry in first_trace] == [0, 1, 2]
+    assert [entry["stage_name"] for entry in first_trace] == [
+        "first",
+        "second",
+        "third",
+    ]
+
+
+def test_pipeline_trace_does_not_mutate_input_dataframe_or_pipeline_state():
+    """Test trace works on copies of both the dataframe and pipeline."""
+    fittable = FittableMarkingStage()
+    pipeline = PdPipeline([fittable, MutatingStage()])
+    df = _test_df()
+    expected_df = df.copy(deep=True)
+
+    trace = pipeline.trace(df)
+
+    pd.testing.assert_frame_equal(df, expected_df)
+    assert "mutated" not in df.columns
+    assert not pipeline.is_fitted
+    assert not fittable.is_fitted
+    assert not hasattr(fittable, "was_fitted")
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["output_columns"] == ["num2", "char"]
+    assert trace[1]["status"] == "applied"
+    assert trace[1]["input_columns"] == ["num2", "char"]
+    assert trace[1]["output_columns"] == ["num2", "char", "mutated"]
 
 
 def test_pipeline_index():

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -80,6 +80,35 @@ class XyTraceStage(PdPipelineStage):
         return df.drop(["num1"], axis=1), y
 
 
+class XyFitTraceStage(PdPipelineStage):
+    """A dataframe and label fit-transformer for trace tests."""
+
+    def _prec(self, df, y):
+        return True
+
+    def _transform(self, df, verbose):
+        return df
+
+    def _fit_transform_Xy(self, df, y, verbose):
+        return df.drop(["num1"], axis=1), y
+
+
+class FittableXyTraceStage(PdPipelineStage):
+    """A fittable dataframe and label transformer for trace tests."""
+
+    def _prec(self, df, y):
+        return True
+
+    def _fit_transform(self, df, verbose):
+        return df
+
+    def _transform(self, df, verbose):
+        return df
+
+    def _transform_Xy(self, df, y, verbose):
+        return df.drop(["num1"], axis=1), y
+
+
 @pytest.mark.parametrize("time", [True, False])
 def test_two_stage_pipeline_stage(time):
     """Testing something."""
@@ -350,6 +379,15 @@ def test_pipeline_trace_reports_skip_callable_stages():
     assert trace[0]["output_columns"] == ["num1", "num2", "char"]
 
 
+def test_pipeline_trace_verbose_emits_stage_message(capsys):
+    """Test verbose trace emits the same stage application message."""
+    pipeline = PdPipeline([SilentDropStage("num1", desc="Drop num1 column")])
+
+    pipeline.trace(_test_df(), verbose=True)
+
+    assert "- Drop num1 column" in capsys.readouterr().out
+
+
 def test_pipeline_trace_evaluates_stage_conditions_once():
     """Test trace does not double-call user conditions."""
     calls = []
@@ -399,6 +437,27 @@ def test_pipeline_trace_reports_failure_and_stops():
     assert trace[1]["output_columns"] is None
     assert trace[1]["error_type"] == "ValueError"
     assert trace[1]["error_message"] == "trace failure"
+
+
+def test_pipeline_trace_reports_fit_postcondition_failure():
+    """Test trace records fit-time postcondition failures."""
+    pipeline = PdPipeline([SilentDropStage("num1", post=lambda df: False)])
+
+    trace = pipeline.trace(_test_df(), exraise=True)
+
+    assert trace[0]["status"] == "failed"
+    assert trace[0]["error_type"] == "FailedPostconditionError"
+
+
+def test_pipeline_trace_reports_transform_postcondition_failure():
+    """Test trace records transform-time postcondition failures."""
+    pipeline = PdPipeline([SilentDropStage("num1", post=lambda df: False)])
+    pipeline.fit(_test_df())
+
+    trace = pipeline.trace(_test_df(), exraise=True)
+
+    assert trace[0]["status"] == "failed"
+    assert trace[0]["error_type"] == "FailedPostconditionError"
 
 
 def test_pipeline_trace_can_report_precondition_failure():
@@ -472,6 +531,29 @@ def test_pipeline_trace_uses_transform_for_fitted_pipelines():
     assert trace[0]["output_columns"] == ["num2", "char"]
 
 
+def test_pipeline_trace_uses_transform_for_fitted_fittable_stages():
+    """Test fitted fittable stages are traced with transform semantics."""
+    pipeline = PdPipeline([FittableMarkingStage()])
+    df = _test_df()
+    pipeline.fit(df)
+
+    trace = pipeline.trace(df)
+
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["output_columns"] == ["num2", "char"]
+
+
+def test_pipeline_trace_reports_unfitted_stage_in_fitted_pipeline():
+    """Test trace records internally inconsistent fitted pipelines."""
+    pipeline = PdPipeline([FittableMarkingStage()])
+    pipeline.is_fitted = True
+
+    trace = pipeline.trace(_test_df())
+
+    assert trace[0]["status"] == "failed"
+    assert trace[0]["error_type"] == "UnfittedPipelineStageError"
+
+
 def test_pipeline_trace_supports_label_transforming_stages():
     """Test trace handles stages that transform both X and y."""
     pipeline = PdPipeline([XyTraceStage()])
@@ -485,6 +567,38 @@ def test_pipeline_trace_supports_label_transforming_stages():
     assert trace[0]["input_columns"] == ["num1", "num2", "char"]
     assert trace[0]["output_shape"] == (2, 2)
     assert trace[0]["output_columns"] == ["num2", "char"]
+
+
+def test_pipeline_trace_supports_label_fit_transforming_stages():
+    """Test trace handles stages that fit-transform both X and y."""
+    pipeline = PdPipeline([XyFitTraceStage()])
+    df = _test_df()
+    y = pd.Series(["a", "b"], index=df.index)
+
+    trace = pipeline.trace(df, y=y)
+
+    assert trace[0]["status"] == "applied"
+    assert trace[0]["output_shape"] == (2, 2)
+    assert trace[0]["output_columns"] == ["num2", "char"]
+
+
+def test_pipeline_trace_supports_label_transforming_fitted_pipelines():
+    """Test trace handles X-y stages in transform mode."""
+    df = _test_df()
+    y = pd.Series(["a", "b"], index=df.index)
+
+    non_fittable = PdPipeline([XyTraceStage()])
+    non_fittable.fit(df, y=y)
+    non_fittable_trace = non_fittable.trace(df, y=y)
+
+    fittable = PdPipeline([FittableXyTraceStage()])
+    fittable.fit(df, y=y)
+    fittable_trace = fittable.trace(df, y=y)
+
+    assert non_fittable_trace[0]["status"] == "applied"
+    assert non_fittable_trace[0]["output_columns"] == ["num2", "char"]
+    assert fittable_trace[0]["status"] == "applied"
+    assert fittable_trace[0]["output_columns"] == ["num2", "char"]
 
 
 def test_pipeline_index():


### PR DESCRIPTION
## Summary
- Add `PdPipeline.trace(...)`, a dependency-free dry-run/local trace API for inspecting how a pipeline applies to a specific dataframe.
- Return structured per-stage dictionaries with deterministic stage order, stage index, class, optional name, description, status, skip reason, input/output shapes, input/output columns, and failure details.
- Run tracing on a deep copy of both the pipeline and input dataframe so an unfitted pipeline can be traced without fitting the original pipeline or mutating caller data.

Closes #158.

## API choice
`trace` is intentionally named as a local/debugging inspection API rather than a rendering API. PR #167 already added the global `to_dot()` visualization slice; this method covers the remaining local slice with a testable data structure and no Graphviz/UI dependency. The default `exraise=False` matches dry-run usage by reporting unmet preconditions as `status="skipped"` with `skip_reason="precondition"`; callers can pass `exraise=True` to report those precondition failures as failed trace entries instead.

## Behavior notes
- If the pipeline is already fitted, trace applies `transform` semantics on the copied pipeline.
- If the pipeline is not fitted, trace applies `fit_transform` semantics on the copied pipeline only.
- Trace stops at the first failed stage and includes the original exception type/message in that stage entry.
- No persistent pipeline state is changed by tracing, and the input dataframe is deep-copied before stage application.

## Validation
- `.venv/bin/python -m black src/pdpipe/core.py tests/core/test_pipeline.py`
- `.venv/bin/python -m flake8 src/pdpipe/core.py tests/core/test_pipeline.py`
- `.venv/bin/python -m pytest tests/core/test_pipeline.py` - 22 passed before the coverage follow-up
- `.venv/bin/python -m pytest tests/core` - 64 passed after the coverage follow-up
- `.venv/bin/python -m coverage json -o /tmp/pdpipe_coverage.json` plus local check of the new trace block - no missing lines in `src/pdpipe/core.py:1993-2146`

## Limitations
- The primary API is structured data; this PR deliberately does not add formatted text rendering, Graphviz rendering, a UI, or a broader debugging framework.
