### PR TITLE
Add opt-in parallel ApplyByCols execution

### DIFF
--- a/src/pdpipe/col_generation.py
+++ b/src/pdpipe/col_generation.py
@@ -399,27 +399,44 @@ class ColumnTransformer(ColumnsBasedPipelineStage):
     ) -> pd.Series:
         raise NotImplementedError
 
+    def _get_result_columns(self, columns):
+        if self._result_columns is not None:
+            return self._result_columns
+        if self._drop:
+            return columns
+        return [f"{col}{self._suffix}" for col in columns]
+
+    def _insert_transformed_column(
+        self,
+        inter_X,
+        X,
+        source_column,
+        result_column,
+        transformed_column,
+    ):
+        loc = X.columns.get_loc(source_column) + 1
+        if self._drop:
+            inter_X = inter_X.drop(source_column, axis=1)
+            loc -= 1
+        return out_of_place_col_insert(
+            X=inter_X,
+            series=transformed_column,
+            loc=loc,
+            column_name=result_column,
+        )
+
     def _transformation(self, X, verbose, fit):
         columns = self._get_columns(X, fit=fit)
-        result_columns = self._result_columns
-        if self._result_columns is None:
-            if self._drop:
-                result_columns = columns
-            else:
-                result_columns = [f"{col}{self._suffix}" for col in columns]
+        result_columns = self._get_result_columns(columns)
         inter_X = X
         for i, colname in enumerate(columns):
             source_col = X[colname]
-            loc = X.columns.get_loc(colname) + 1
-            new_name = result_columns[i]
-            if self._drop:
-                inter_X = inter_X.drop(colname, axis=1)
-                loc -= 1
-            inter_X = out_of_place_col_insert(
-                X=inter_X,
-                series=self._col_transform(source_col, colname),
-                loc=loc,
-                column_name=new_name,
+            inter_X = self._insert_transformed_column(
+                inter_X=inter_X,
+                X=X,
+                source_column=colname,
+                result_column=result_columns[i],
+                transformed_column=self._col_transform(source_col, colname),
             )
         return inter_X
 
@@ -799,31 +816,6 @@ class ApplyByCols(ColumnTransformer):
             raise ValueError("n_jobs must be a positive integer, -1, or None.")
         return n_jobs
 
-    @staticmethod
-    def _resolve_result_columns(columns, result_columns, drop, suffix):
-        if result_columns is not None:
-            return result_columns
-        if drop:
-            return columns
-        return [f"{col}{suffix}" for col in columns]
-
-    @staticmethod
-    def _insert_transformed_columns(X, columns, result_columns, drop, series):
-        inter_X = X
-        for i, colname in enumerate(columns):
-            loc = X.columns.get_loc(colname) + 1
-            new_name = result_columns[i]
-            if drop:
-                inter_X = inter_X.drop(colname, axis=1)
-                loc -= 1
-            inter_X = out_of_place_col_insert(
-                X=inter_X,
-                series=series[i],
-                loc=loc,
-                column_name=new_name,
-            )
-        return inter_X
-
     def _parallel_col_transform(self, X, columns, max_workers):
         def transform_col(colname):
             return self._col_transform(X[colname], colname)
@@ -836,24 +828,22 @@ class ApplyByCols(ColumnTransformer):
         if n_jobs == 1:
             return super()._transformation(X=X, verbose=verbose, fit=fit)
         columns = self._get_columns(X, fit=fit)
-        result_columns = self._resolve_result_columns(
-            columns=columns,
-            result_columns=self._result_columns,
-            drop=self._drop,
-            suffix=self._suffix,
-        )
-        series = self._parallel_col_transform(
+        result_columns = self._get_result_columns(columns)
+        transformed_columns = self._parallel_col_transform(
             X=X,
             columns=columns,
             max_workers=n_jobs,
         )
-        return self._insert_transformed_columns(
-            X=X,
-            columns=columns,
-            result_columns=result_columns,
-            drop=self._drop,
-            series=series,
-        )
+        inter_X = X
+        for i, colname in enumerate(columns):
+            inter_X = self._insert_transformed_column(
+                inter_X=inter_X,
+                X=X,
+                source_column=colname,
+                result_column=result_columns[i],
+                transformed_column=transformed_columns[i],
+            )
+        return inter_X
 
     def _col_transform(
         self,

--- a/src/pdpipe/col_generation.py
+++ b/src/pdpipe/col_generation.py
@@ -15,7 +15,9 @@ Available stages include:
 """
 
 import abc
+from concurrent.futures import ThreadPoolExecutor
 import inspect
+import os
 import warnings
 from typing import Callable, Dict, Optional, Tuple, Union
 
@@ -711,6 +713,14 @@ class ApplyByCols(ColumnTransformer):
         of '_app'.
     args : tuple, optional
         Positional arguments to pass to func in addition to the array/series.
+    n_jobs : int, default None
+        Number of worker threads to use when applying the function. If None
+        or 1, the existing serial implementation is used. If -1, all
+        available CPUs are used. Parallel execution uses Python's standard
+        thread pool, so it works with non-picklable callables but is best
+        suited for functions that release the GIL or spend time on I/O.
+        Functions should not depend on shared mutable state or call ordering
+        when parallel execution is enabled.
     **kwargs : dict, optional
         Additional keyword arguments to pass as keywords arguments to func.
         Valid constructor parameters of superclasses are extracted and used
@@ -739,9 +749,11 @@ class ApplyByCols(ColumnTransformer):
         func_desc=None,
         suffix=None,
         args=(),
+        n_jobs=None,
         **kwargs,
     ):
         self._func = func
+        self._n_jobs = n_jobs
         self._inject_label = False
         self._inject_fit_context = False
         self._inject_application_context = False
@@ -775,6 +787,74 @@ class ApplyByCols(ColumnTransformer):
         super_kwargs.update(**init_kwargs)
         super().__init__(**super_kwargs)
 
+    @staticmethod
+    def _effective_n_jobs(n_jobs):
+        if n_jobs is None:
+            return 1
+        if n_jobs == -1:
+            return os.cpu_count() or 1
+        if not isinstance(n_jobs, int):
+            raise TypeError("n_jobs must be an integer, -1, 1, or None.")
+        if n_jobs < 1:
+            raise ValueError("n_jobs must be a positive integer, -1, or None.")
+        return n_jobs
+
+    @staticmethod
+    def _resolve_result_columns(columns, result_columns, drop, suffix):
+        if result_columns is not None:
+            return result_columns
+        if drop:
+            return columns
+        return [f"{col}{suffix}" for col in columns]
+
+    @staticmethod
+    def _insert_transformed_columns(X, columns, result_columns, drop, series):
+        inter_X = X
+        for i, colname in enumerate(columns):
+            loc = X.columns.get_loc(colname) + 1
+            new_name = result_columns[i]
+            if drop:
+                inter_X = inter_X.drop(colname, axis=1)
+                loc -= 1
+            inter_X = out_of_place_col_insert(
+                X=inter_X,
+                series=series[i],
+                loc=loc,
+                column_name=new_name,
+            )
+        return inter_X
+
+    def _parallel_col_transform(self, X, columns, max_workers):
+        def transform_col(colname):
+            return self._col_transform(X[colname], colname)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(transform_col, columns))
+
+    def _transformation(self, X, verbose, fit):
+        n_jobs = self._effective_n_jobs(self._n_jobs)
+        if n_jobs == 1:
+            return super()._transformation(X=X, verbose=verbose, fit=fit)
+        columns = self._get_columns(X, fit=fit)
+        result_columns = self._resolve_result_columns(
+            columns=columns,
+            result_columns=self._result_columns,
+            drop=self._drop,
+            suffix=self._suffix,
+        )
+        series = self._parallel_col_transform(
+            X=X,
+            columns=columns,
+            max_workers=n_jobs,
+        )
+        return self._insert_transformed_columns(
+            X=X,
+            columns=columns,
+            result_columns=result_columns,
+            drop=self._drop,
+            series=series,
+        )
+
     def _col_transform(
         self,
         series: pd.Series,
@@ -782,7 +862,7 @@ class ApplyByCols(ColumnTransformer):
         fit_context: Optional[PdpApplicationContext] = None,
         application_context: Optional[PdpApplicationContext] = None,
     ) -> pd.Series:
-        kwargs = self._apply_kwargs
+        kwargs = dict(self._apply_kwargs)
         if self._inject_label:
             kwargs["label"] = label
         if self._inject_fit_context:

--- a/src/pdpipe/col_generation.py
+++ b/src/pdpipe/col_generation.py
@@ -15,10 +15,10 @@ Available stages include:
 """
 
 import abc
-from concurrent.futures import ThreadPoolExecutor
 import inspect
 import os
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Dict, Optional, Tuple, Union
 
 import numpy as np

--- a/tests/col_generation/test_applybycols.py
+++ b/tests/col_generation/test_applybycols.py
@@ -21,6 +21,27 @@ def ph_df():
     )
 
 
+def multi_col_df():
+    return pd.DataFrame(
+        data=[
+            ["x", 1, "m1", 10, "z1"],
+            ["y", 2, "m2", 20, "z2"],
+            ["z", 3, "m3", 30, "z3"],
+        ],
+        index=["row-c", "row-a", "row-b"],
+        columns=["id", "a", "middle", "b", "tail"],
+    )
+
+
+def _add_by_label(value, offset=0, label=None):
+    label_offset = {"a": 100, "b": 200}[label]
+    return value + offset + label_offset
+
+
+def _subtract_context_offset(value, label, application_context):
+    return value - application_context["offsets"][label]
+
+
 def test_applybycols():
     """Testing ApplyByCols pipeline stages."""
     df = ph_df()
@@ -73,6 +94,141 @@ def test_applybycols_with_bad_len_result_columns():
     """Testing ApplyByCols pipeline stages."""
     with pytest.raises(ValueError):
         ApplyByCols("ph", math.ceil, result_columns=["a", "b"])
+
+
+def test_applybycols_parallel_matches_serial():
+    """Testing opt-in ApplyByCols parallel execution."""
+    df = multi_col_df()
+    serial_stage = ApplyByCols(
+        ["a", "b"],
+        _add_by_label,
+        drop=False,
+        suffix="_app",
+        args=(5,),
+        n_jobs=1,
+    )
+    parallel_stage = ApplyByCols(
+        ["a", "b"],
+        _add_by_label,
+        drop=False,
+        suffix="_app",
+        args=(5,),
+        n_jobs=2,
+    )
+    serial_df = serial_stage(df)
+    parallel_df = parallel_stage(df)
+    pd.testing.assert_frame_equal(parallel_df, serial_df)
+
+
+def test_applybycols_parallel_with_result_columns_matches_serial():
+    """Testing ApplyByCols parallel custom result column names."""
+    df = multi_col_df()
+    serial_stage = ApplyByCols(
+        ["a", "b"],
+        _add_by_label,
+        result_columns=["a_new", "b_new"],
+        args=(5,),
+        n_jobs=1,
+    )
+    parallel_stage = ApplyByCols(
+        ["a", "b"],
+        _add_by_label,
+        result_columns=["a_new", "b_new"],
+        args=(5,),
+        n_jobs=2,
+    )
+    serial_df = serial_stage(df)
+    parallel_df = parallel_stage(df)
+    pd.testing.assert_frame_equal(parallel_df, serial_df)
+    assert list(parallel_df.columns) == [
+        "id",
+        "a_new",
+        "middle",
+        "b_new",
+        "tail",
+    ]
+
+
+def test_applybycols_parallel_n_jobs_minus_one_matches_serial():
+    """Testing ApplyByCols n_jobs=-1 compatibility."""
+    df = multi_col_df()
+    serial_stage = ApplyByCols(["a", "b"], _add_by_label, n_jobs=1)
+    parallel_stage = ApplyByCols(["a", "b"], _add_by_label, n_jobs=-1)
+    pd.testing.assert_frame_equal(parallel_stage(df), serial_stage(df))
+
+
+def test_applybycols_parallel_rejects_invalid_n_jobs():
+    """Testing ApplyByCols n_jobs validation."""
+    df = multi_col_df()
+    with pytest.raises(TypeError):
+        ApplyByCols(["a", "b"], _add_by_label, n_jobs="2")(df)
+    with pytest.raises(ValueError):
+        ApplyByCols(["a", "b"], _add_by_label, n_jobs=0)(df)
+
+
+def test_applybycols_parallel_preserves_column_order_and_index():
+    """Testing ApplyByCols parallel output shape invariants."""
+    df = multi_col_df()
+    parallel_stage = ApplyByCols(
+        ["a", "b"],
+        _add_by_label,
+        drop=False,
+        suffix="_parallel",
+        args=(5,),
+        n_jobs=2,
+    )
+    res_df = parallel_stage(df)
+    assert list(res_df.index) == ["row-c", "row-a", "row-b"]
+    assert list(res_df.columns) == [
+        "id",
+        "a",
+        "a_parallel",
+        "middle",
+        "b_parallel",
+        "b",
+        "tail",
+    ]
+
+
+def test_applybycols_n_jobs_none_and_one_use_serial_behavior():
+    """Testing ApplyByCols default n_jobs compatibility."""
+    df = multi_col_df()
+    default_stage = ApplyByCols(["a", "b"], _add_by_label)
+    none_stage = ApplyByCols(["a", "b"], _add_by_label, n_jobs=None)
+    one_stage = ApplyByCols(["a", "b"], _add_by_label, n_jobs=1)
+    default_df = default_stage(df)
+    pd.testing.assert_frame_equal(none_stage(df), default_df)
+    pd.testing.assert_frame_equal(one_stage(df), default_df)
+
+
+def test_applybycols_parallel_matches_serial_with_application_context():
+    """Testing ApplyByCols parallel context injection."""
+    df = multi_col_df()
+    serial_pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(
+                offsets=lambda X: {col: X[col].min() for col in ["a", "b"]},
+            ),
+            pdp.ApplyByCols(
+                ["a", "b"],
+                _subtract_context_offset,
+                n_jobs=1,
+            ),
+        ]
+    )
+    parallel_pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(
+                offsets=lambda X: {col: X[col].min() for col in ["a", "b"]},
+            ),
+            pdp.ApplyByCols(
+                ["a", "b"],
+                _subtract_context_offset,
+                n_jobs=2,
+            ),
+        ]
+    )
+    pd.testing.assert_frame_equal(parallel_pipeline(df), serial_pipeline(df))
 
 
 # def _num_df():


### PR DESCRIPTION
## Summary
- Add an opt-in `n_jobs` parameter to `ApplyByCols`.
- Keep `n_jobs=None` and `n_jobs=1` on the existing inherited serial `ColumnTransformer` path.
- Add a conservative stdlib `ThreadPoolExecutor` path for `n_jobs > 1` and `n_jobs=-1`.
- Preserve result column resolution, column insertion order, source index alignment, application-context injection, and existing serial behavior.

## Design Notes
- Default behavior remains no parallelization. Omitted `n_jobs`, `None`, and `1` all use the current serial implementation.
- The parallel backend uses threads rather than processes so existing non-picklable callables, lambdas, and context injection remain usable. This is most useful for I/O-heavy functions or functions that release the GIL; users should not depend on shared mutable state or call ordering when parallel mode is enabled.
- This PR intentionally implements the first #163 slice only for `ApplyByCols`. `ApplyToRows` remains a follow-up because its row-wise return-shape behavior has broader surface area.

## Validation
- `.venv/bin/python -m black src/pdpipe/col_generation.py tests/col_generation/test_applybycols.py`
- `.venv/bin/python -m flake8 src/pdpipe/col_generation.py tests/col_generation/test_applybycols.py`
- `.venv/bin/python -m pytest tests/col_generation/test_applybycols.py -q`
- `.venv/bin/python -m pytest tests/col_generation -q`

Refs #163