### PR TITLE
Update README and docs for current APIs

### DIFF
--- a/.readthedocs.mkdocs.yml
+++ b/.readthedocs.mkdocs.yml
@@ -2,9 +2,9 @@ site_name: pdpipe
 site_url: https://pdpipe.readthedocs.io/en/latest/
 repo_name: pdpipe
 repo_url: https://github.com/pdpipe/pdpipe
-edit_uri: edit/master/doc
+edit_uri: edit/master/docs
 docs_dir: docs
-copyright: © Copyright 2022 Shay Palachy | All Rights Reserved.
+copyright: © Copyright 2026 Shay Palachy | All Rights Reserved.
 nav:
   - Home:
       - index.md
@@ -81,14 +81,13 @@ theme:
 plugins:
   - search
   - git-revision-date
-  - mkdocs-jupyter
   - awesome-pages
   - mkdocstrings:
       default_handler: python
       handlers:
         python:
           rendering:
-            show_source: true
+            show_source: false
             show_category_heading: true
             members_order: source
             show_if_no_docstring: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,10 @@ formats: all
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 python:
   install:
     - requirements: docs/mkdocs/requirements.txt
+    - method: pip
+      path: .

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,24 @@ Easy pipelines for pandas DataFrames (`learn how! <https://tirthajyoti.github.io
       Jane     180        1         0
       Nick     170        0         0
 
+Highlights
+==========
+
+``pdpipe`` includes ready-made stages for common pandas preprocessing tasks,
+including column dropping, value filtering, one-hot encoding, column mapping,
+row-wise feature generation, dataframe-wide feature generation, and
+scikit-learn-style transformations.
+
+Recent APIs include:
+
+* ``PdPipeline.to_dot()`` for dependency-free Graphviz DOT pipeline diagrams.
+* ``PdPipeline.trace()`` for structured per-stage dry-run diagnostics.
+* ``Diff`` for applying ``pandas.Series.diff`` to selected columns.
+* ``SklearnColumnTransform`` for wrapping arbitrary matrix-to-matrix
+  scikit-learn transformers while preserving DataFrame column context.
+* Optional ``n_jobs`` thread-based parallel execution in ``ApplyByCols`` and
+  ``ApplyToRows``. Serial execution remains the default.
+
 .. .. alternative symbols: ˨ ᛪ ᛢ ᚶ ᚺ ↬ ⑀ ⤃ ⤳ ⥤ 』
 
 .. contents::

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,15 @@ pipelines have a simple interface, informative prints and errors on pipeline
 application, support pipeline arithmetics and enable easier handling of
 mixed-type data.
 
+Current releases include tools for inspecting pipeline structure and runtime
+behavior: `PdPipeline.to_dot()` exports dependency-free Graphviz DOT diagrams,
+and `PdPipeline.trace()` returns structured per-stage diagnostics for a
+dataframe run. Column-generation stages include `Diff` for
+`pandas.Series.diff`, and `ApplyByCols` / `ApplyToRows` can opt into
+thread-based parallel execution with `n_jobs` while keeping serial execution as
+the default. Scikit-learn users can wrap arbitrary matrix-to-matrix
+transformers with `SklearnColumnTransform`.
+
 ```py
 >>> df = pd.DataFrame(
         data=[[4, 165, 'USA'], [2, 180, 'UK'], [2, 170, 'Greece']],

--- a/docs/mkdocs/requirements.txt
+++ b/docs/mkdocs/requirements.txt
@@ -1,13 +1,16 @@
+Markdown<3.4
+mkdocs>=1.3,<1.5
 mkdocs-material==8.3.9
-mkdocs-jupyter==0.19.0
 python-markdown-math==0.8
+pymdown-extensions>=9.4,<10
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-plugin
-mkdocstrings[python]>=0.18
+mkdocs-autorefs<0.5
+mkdocstrings>=0.18,<0.19
+mkdocstrings-python-legacy>=0.2,<0.3
 GitPython
 scikit-learn
 nltk
-git+https://github.com/pdpipe/pdpipe.git
-pytkdocs[numpy-style]>=0.5.0
+pytkdocs[numpy-style]>=0.5.0,<0.17
 # specifically fixed deps by Shay
-griffe>=0.22.2
+griffe>=0.22.2,<1

--- a/docs/starting/pipelines.md
+++ b/docs/starting/pipelines.md
@@ -35,6 +35,27 @@ A pdpipe pipeline:
 [ 2]  Map values of column Job with {'Part': True, 'Full': True, 'No': False}
 ```
 
+## Exporting Pipeline Graphs
+
+`PdPipeline.to_dot()` returns a dependency-free Graphviz DOT representation of
+the pipeline. Node labels include each stage's index, class name, optional
+stage name, and description. The returned string can be written to a `.dot`
+file or passed to Graphviz tooling.
+
+<!--phmdoctest-skip-->
+
+```python
+>>> pipeline = pdp.ColDrop("Name").OneHotEncode("Label")
+>>> print(pipeline.to_dot())
+digraph PdPipeline {
+  graph [rankdir=LR];
+  node [shape=box];
+  stage_0 [label="[0] ColDrop\nDrop columns 'Name'"];
+  stage_1 [label="[1] OneHotEncode\nOne-hot encode 'Label'"];
+  stage_0 -> stage_1;
+}
+```
+
 ## Pipeline Arithmetics
 
 Alternatively, you can create pipelines by adding pipeline stages together:
@@ -109,3 +130,28 @@ res_df = pipeline.apply(df, verbose=True)
 ```
 
 Finally, `fit`, `transform` and `fit_transform` all call the corresponding pipeline stage methods of all stages composing the pipeline.
+
+## Tracing Pipeline Application
+
+`PdPipeline.trace()` applies a deep-copied pipeline to a deep-copied dataframe
+and returns structured records describing each visited stage. It is useful for
+debugging pipeline behavior without fitting or mutating the original pipeline
+or input dataframe.
+
+Each trace entry includes the stage index, class, optional name, description,
+status, skip reason, input/output shapes, input/output columns, and error
+details if the stage failed.
+
+<!--phmdoctest-skip-->
+
+```python
+>>> pipeline = pdp.ColDrop("Name").OneHotEncode("Label")
+>>> trace = pipeline.trace(df)
+>>> first_stage = trace[0]
+>>> first_stage.get("status")
+'applied'
+>>> first_stage.get("input_columns")
+['Name', 'Label', 'Children']
+>>> first_stage.get("output_columns")
+['Label', 'Children']
+```

--- a/docs/starting/types.md
+++ b/docs/starting/types.md
@@ -62,6 +62,9 @@ Refer to submodule `pdpipe.col_generation`
   Supports opt-in thread-based parallel execution with `n_jobs`; by default,
   the existing serial row-apply path is used.
 - ApplyByCols - Generate columns by applying an element-wise function to columns.
+  Supports opt-in thread-based parallel execution with `n_jobs`; by default,
+  the existing serial column-apply path is used.
+- Diff - Replace or add columns containing `pandas.Series.diff` results.
 - ColByFrameFunc - Add a column by applying a dataframe-wide function.
 - AggByCols - Generate columns by applying an series-wise function to columns.
 - Log - Log-transform numeric data, possibly shifting data before.
@@ -80,6 +83,9 @@ Refer to submodule `pdpipe.sklearn_stages`
 
 - Encode - Encode a categorical column to corresponding number values.
 - Scale - Scale data with any of the sklearn scalers.
+- SklearnColumnTransform - Apply an arbitrary matrix-to-matrix scikit-learn
+  transformer to selected DataFrame columns while preserving column labels and
+  passthrough columns.
 - TfidfVectorizeTokenLists - Transform a column of token lists into the correponding set of tfidf vector columns.
 
 ## nltk-dependent Stages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,11 +4,45 @@ repo_name: pdpipe
 repo_url: https://github.com/pdpipe/pdpipe
 edit_uri: edit/master/docs
 docs_dir: docs
+copyright: © Copyright 2026 Shay Palachy | All Rights Reserved.
 nav:
-  - Home: index.md
-  - Tutorial:
-      - Usage:
-          - tutorial/README.md
+  - Home:
+      - index.md
+      - More on pdpipe: more.md
+  - Getting Started:
+      - Installation: starting/install.md
+      - First Use: starting/first_use.md
+      - Pipeline Stages: starting/stages.md
+      - Pipelines: starting/pipelines.md
+      - Types of Stages: starting/types.md
+      - Fly Handles: starting/fly.md
+      - Conditions: starting/cond.md
+      - Column Qualifiers: starting/cq.md
+      - Wrappers: starting/wrappers.md
+  - Develop:
+      - develop/adhoc.md
+      - develop/custom.md
+  - Tutorials:
+      - tutorials/index.md
+      - Halving Columns: tutorials/half.md
+      - Standartizing: tutorials/standard_df.md
+      - Building Pipelines: tutorials/building_pipelines.md
+      - Custom Stages: tutorials/custom_stages.md
+      - pdpipe and sklearn: tutorials/skintegrate.md
+      - Runtime Parameters: tutorials/runtime_parameters.md
+  - API Reference:
+      - Core: reference/core.md
+      - Basic Stages: reference/basic.md
+      - Column Generation: reference/col_generation.md
+      - Scikit-learn Stages: reference/sklearn.md
+      - Scikit-learn Integrations: reference/skintegrate.md
+      - Text Stages: reference/text.md
+      - NLTK Stages: reference/nltk.md
+      - Fly Handles: reference/fly.md
+      - Conditions: reference/cond.md
+      - Column Qualifiers: reference/cq.md
+      - Wrappers: reference/wrappers.md
+      - Run time parameters: reference/runtime_parameters.md
 theme:
   name: material
   features:
@@ -19,6 +53,7 @@ theme:
     # - navigation.instant
     - navigation.tracking
     - header.autohide
+    - content.code.annotate
   icon:
     repo: fontawesome/brands/github
   language: en
@@ -26,6 +61,7 @@ theme:
     text: Roboto
     code: Roboto Mono
   favicon: images/logo.png
+  logo: "images/white_logo.png"
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -41,3 +77,65 @@ theme:
       toggle:
         icon: material/lightbulb-outline
         name: Switch to light mode
+
+plugins:
+  - search
+  - git-revision-date
+  - awesome-pages
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          rendering:
+            show_source: false
+            show_category_heading: true
+            members_order: source
+            show_if_no_docstring: true
+          selection:
+            docstring_style: numpy
+            filters: ["!^_"]
+
+# for how to adjust the filters selecting which functions get collected, see:
+# https://mkdocstrings.github.io/pytkdocs/#configuration
+
+# for code blocks syntax highlighting
+markdown_extensions:
+  - admonition
+  - footnotes
+  - codehilite
+  - tables
+  - attr_list
+  - md_in_html
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/pdpipe/pdpipe
+    - icon: fontawesome/solid/comments
+      link: https://github.com/pdpipe/pdpipe/discussions
+    - icon: fontawesome/brands/gitter
+      link: https://gitter.im/pdpipe/community
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/pdpipe/
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/shaypal5
+
+extra_css:
+  - "mkdocs/css/termynal.css"
+  - "mkdocs/css/custom.css"
+  - "mkdocs/css/extra.css"
+  - "mkdocs/css/admonitions.css"
+
+extra_javascript:
+  - "mkdocs/js/termynal.js"
+  - "mkdocs/js/custom.js"
+  - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML"


### PR DESCRIPTION
## Summary

Updates the README and documentation site sources so they cover the current pdpipe API surface after the recent feature work.

## What changed

- Added README and docs-home highlights for current APIs: `PdPipeline.to_dot()`, `PdPipeline.trace()`, `Diff`, `SklearnColumnTransform`, and `n_jobs` support in `ApplyByCols` / `ApplyToRows`.
- Expanded the pipeline docs with short sections for exporting Graphviz DOT and tracing pipeline application.
- Updated the stage-type overview to mention `ApplyByCols n_jobs`, `Diff`, and `SklearnColumnTransform`.
- Fixed the root MkDocs navigation, which still pointed at `docs/tutorial/README.md` even though the repo uses `docs/tutorials/`.
- Aligned the root MkDocs config with the ReadTheDocs config so local and hosted docs render the API reference through mkdocstrings.
- Updated the ReadTheDocs build to Python 3.10, install the current checkout instead of `git+https://github.com/pdpipe/pdpipe.git`, and remove the unused `mkdocs-jupyter` dependency/plugin that breaks current builds.

## Impact

Users should see the recently added APIs in both narrative docs and generated API reference pages once the docs site rebuilds. The docs build now uses the checked-out package source, so PR and branch builds reflect the code being documented instead of whatever is installed from GitHub separately.

## Validation

- `.venv/bin/mkdocs build -f .readthedocs.mkdocs.yml`
- `.venv/bin/mkdocs build -f mkdocs.yml`
- Rendered `README.rst` with docutils to `/tmp/pdpipe-readme.html`
- `.venv/bin/python -m black .`
- `.venv/bin/python -m flake8 src tests`

Note: a raw `.venv/bin/python -m flake8` run in this local environment scans `.venv/` and `build/` because this flake8 invocation does not consume the pyproject exclude list; the project source/test scoped run passes.

## Follow-up

The MkDocs build still emits deprecation warnings from the legacy Material/mkdocstrings theme stack. They are non-fatal with the current ReadTheDocs `fail_on_warning: false` setting, but a future docs modernization PR should migrate the theme/emoji/mkdocstrings configuration more broadly.
