### PR TITLE
Add contextual runtime parameters

### DIFF
--- a/docs/tutorials/runtime_parameters.md
+++ b/docs/tutorials/runtime_parameters.md
@@ -1,4 +1,4 @@
-# Dynamic Runtime Parameters
+# Runtime Parameters
 
 In some cases one wishes to set a parameter based on calculations done
 in real time, based on the given input. Dynamic parameters help to achieve
@@ -35,6 +35,49 @@ pipeline = pdp.PdPipeline(
         pdp.ColDrop(pdp.cq.StartWith("n_")),  # unrelated to scaling
         pdp.Scale(
             scaler=pdp.dynamic(scaling_decider, fit=False),
+            joint=True,
+        ),
+    ]
+)
+```
+
+## Contextual Parameters
+
+`pdp.contextual` creates a placeholder for a stage constructor parameter whose
+value is produced earlier in the same pipeline application. The placeholder is
+resolved from the pipeline fit context by default. Use `fit=False` to resolve
+it from the application context on every pipeline application.
+
+The stage keeps the placeholder between applications; the concrete value is
+only swapped in while that stage is running. Contextual placeholders can appear
+as direct constructor attributes, or inside simple built-in containers and
+mapping objects stored as constructor attributes. Treat those contextual
+constructor attributes as immutable parameter templates: mutations made to
+them while a stage is running are discarded when the original placeholders are
+restored.
+
+```python
+import numpy as np
+import pandas as pd
+import pdpipe as pdp
+
+
+def scaling_decider(X: pd.DataFrame) -> str:
+    """
+    Determines what scaler to apply by examining all numerical columns.
+    """
+    numX = X.select_dtypes(include=np.number)
+    for col in numX.columns:
+        if np.std(numX[col]) > 2 * np.mean(numX[col]):
+            return "StandardScaler"
+    return "MinMaxScaler"
+
+
+pipeline = pdp.PdPipeline(
+    stages=[
+        pdp.ApplicationContextEnricher(scaling_type=scaling_decider),
+        pdp.Scale(
+            scaler=pdp.contextual("scaling_type", fit=False),
             joint=True,
         ),
     ]

--- a/src/pdpipe/__init__.py
+++ b/src/pdpipe/__init__.py
@@ -169,7 +169,7 @@ from .nltk_stages import (
 core.__load_stage_attributes_from_module__("pdpipe.nltk_stages")
 
 from . import run_time_parameters
-from .run_time_parameters import dynamic
+from .run_time_parameters import contextual, dynamic
 
 from .df import DF_HANDLE as df
 
@@ -181,6 +181,7 @@ __all__.extend(
     [
         "run_time_parameters",
         "dynamic",
+        "contextual",
         "df",
         "cq",
         "rq",

--- a/src/pdpipe/core.py
+++ b/src/pdpipe/core.py
@@ -2,6 +2,7 @@
 
 import abc
 import collections
+import contextlib
 import copy
 import inspect
 import re
@@ -14,7 +15,7 @@ import numpy
 import pandas
 import pandas as pd
 
-from .run_time_parameters import DynamicParameter
+from .run_time_parameters import ContextualParameter, DynamicParameter
 
 try:
     from pympler.asizeof import asizeof
@@ -380,7 +381,9 @@ class PdPipelineStage(abc.ABC):
         self._is_being_applied = False
         self._is_being_fitted = False
         self._dynamics = []  # list of parameters to be decided at runtime
+        self._contextual_params = []
         self._process_dynamics()
+        self._process_contextuals()
 
     def is_being_fitted_by_pipeline(self) -> bool:
         """Return True if this stage is being fitted, False otherwise.
@@ -412,6 +415,7 @@ class PdPipelineStage(abc.ABC):
         "application_context",
         "is_fitted",
         "_dynamics",
+        "_contextual_params",
         "_failed_precondition",
         "_failed_postcondition",
     }
@@ -431,6 +435,145 @@ class PdPipelineStage(abc.ABC):
             attr_obj = self.__getattribute__(attr)
             if isinstance(attr_obj, DynamicParameter):
                 self._dynamics.append({"name": attr, "callable": attr_obj})
+
+    def _use_dynamics(
+        self,
+        X: pd.DataFrame,
+        y: Optional[pd.Series] = None,
+    ) -> None:
+        """Set dynamic parameters based on the given input."""
+        for dynamic in self._dynamics:
+            param = (
+                dynamic["callable"](X)
+                if y is None
+                else dynamic["callable"](X, y)
+            )
+            setattr(self, dynamic["name"], param)
+
+    @staticmethod
+    def _has_contextual_parameter(value) -> bool:
+        """Return True if the given value includes a contextual parameter."""
+        if isinstance(value, ContextualParameter):
+            return True
+        if isinstance(value, collections.abc.Mapping):
+            return any(
+                PdPipelineStage._has_contextual_parameter(item)
+                for pair in value.items()
+                for item in pair
+            )
+        if isinstance(value, (list, tuple, set)):
+            return any(
+                PdPipelineStage._has_contextual_parameter(item)
+                for item in value
+            )
+        return False
+
+    def _process_contextuals(self) -> None:
+        """Create a list of contextual attributes of this stage."""
+        potential_contextual_attrs = set(self.__dict__).difference(
+            self.class_attrs
+        )
+        for attr in potential_contextual_attrs:
+            attr_obj = self.__getattribute__(attr)
+            if self._has_contextual_parameter(attr_obj):
+                self._contextual_params.append(
+                    {"name": attr, "template": attr_obj}
+                )
+
+    @staticmethod
+    def _resolve_contextual_mapping(
+        value,
+        fit_context,
+        application_context,
+    ):
+        """Resolve contextual parameters nested in mapping keys and values."""
+        return {
+            PdPipelineStage._resolve_contextual_value(
+                key, fit_context, application_context
+            ): PdPipelineStage._resolve_contextual_value(
+                val, fit_context, application_context
+            )
+            for key, val in value.items()
+        }
+
+    @staticmethod
+    def _resolve_contextual_items(
+        value,
+        fit_context,
+        application_context,
+    ):
+        """Resolve contextual parameters nested in iterable items."""
+        return (
+            PdPipelineStage._resolve_contextual_value(
+                item, fit_context, application_context
+            )
+            for item in value
+        )
+
+    @staticmethod
+    def _resolve_contextual_value(value, fit_context, application_context):
+        """Resolve contextual parameters nested in simple containers."""
+        if isinstance(value, ContextualParameter):
+            return value.resolve(fit_context, application_context)
+        if isinstance(value, collections.abc.Mapping):
+            return PdPipelineStage._resolve_contextual_mapping(
+                value, fit_context, application_context
+            )
+        if isinstance(value, list):
+            return list(
+                PdPipelineStage._resolve_contextual_items(
+                    value,
+                    fit_context,
+                    application_context,
+                )
+            )
+        if isinstance(value, tuple):
+            return tuple(
+                PdPipelineStage._resolve_contextual_items(
+                    value, fit_context, application_context
+                )
+            )
+        if isinstance(value, set):
+            return set(
+                PdPipelineStage._resolve_contextual_items(
+                    value,
+                    fit_context,
+                    application_context,
+                )
+            )
+        return value
+
+    @contextlib.contextmanager
+    def _use_contextuals(self):
+        """Temporarily swap contextual attributes with concrete values."""
+        if not self._contextual_params:
+            yield
+            return
+        originals = {}
+        try:
+            for contextual_param in self._contextual_params:
+                name = contextual_param["name"]
+                originals[name] = getattr(self, name)
+                try:
+                    resolved_value = self._resolve_contextual_value(
+                        contextual_param["template"],
+                        self.fit_context,
+                        self.application_context,
+                    )
+                except KeyError as e:
+                    raise PipelineApplicationError(f"{self}: {e}") from e
+                setattr(self, name, resolved_value)
+            yield
+        finally:
+            for name, value in originals.items():
+                setattr(self, name, value)
+
+    @contextlib.contextmanager
+    def _use_runtime_parameters(self, X, y=None):
+        """Resolve stage runtime parameters while applying this stage."""
+        self._use_dynamics(X, y)
+        with self._use_contextuals():
+            yield
 
     @classmethod
     def _init_kwargs(cls):
@@ -860,41 +1003,44 @@ class PdPipelineStage(abc.ABC):
 
         """
         with AppContextMgr(self, fit=True):
-            if exraise is None:
-                exraise = self._exraise
-            if self._should_skip(X, y):
+            with self._use_runtime_parameters(X, y):
+                if exraise is None:
+                    exraise = self._exraise
+                if self._should_skip(X, y):
+                    if y is not None:
+                        return X, y
+                    return X
+                if y is not None:
+                    y = self._cast_y_to_series(X, y)
+                if self._compound_prec(X, y, fit=True):
+                    if verbose:
+                        msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                        print(msg, flush=True)
+                    if self._is_an_Xy_fit_transformer:
+                        res_X, res_y = self._fit_transform_Xy(
+                            X, y, verbose=verbose
+                        )
+                    elif self._is_an_Xy_transformer:
+                        res_X, res_y = self._transform_Xy(
+                            X, y, verbose=verbose
+                        )
+                    else:
+                        res_X = self._fit_transform(X, verbose=verbose)
+                        res_y = y
+                    self.is_fitted = True
+                    if exraise and not self._compound_post(
+                        X=res_X, y=res_y, fit=True
+                    ):
+                        self._raise_postcondition_error()
+                    if y is not None:
+                        res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                        return res_X, res_y
+                    return res_X
+                if exraise:
+                    self._raise_precondition_error()
                 if y is not None:
                     return X, y
                 return X
-            if y is not None:
-                y = self._cast_y_to_series(X, y)
-            if self._compound_prec(X, y, fit=True):
-                if verbose:
-                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                    print(msg, flush=True)
-                if self._is_an_Xy_fit_transformer:
-                    res_X, res_y = self._fit_transform_Xy(
-                        X, y, verbose=verbose
-                    )
-                elif self._is_an_Xy_transformer:
-                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-                else:
-                    res_X = self._fit_transform(X, verbose=verbose)
-                    res_y = y
-                self.is_fitted = True
-                if exraise and not self._compound_post(
-                    X=res_X, y=res_y, fit=True
-                ):
-                    self._raise_postcondition_error()
-                if y is not None:
-                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                    return res_X, res_y
-                return res_X
-            if exraise:
-                self._raise_precondition_error()
-            if y is not None:
-                return X, y
-            return X
 
     def fit(self, X, y=None, exraise=None, verbose=False):
         """Fit this stage without transforming the given dataframe.
@@ -953,58 +1099,64 @@ class PdPipelineStage(abc.ABC):
 
         """
         with AppContextMgr(self):
-            if exraise is None:
-                exraise = self._exraise
-            if self._should_skip(X, y):
+            with self._use_runtime_parameters(X, y):
+                if exraise is None:
+                    exraise = self._exraise
+                if self._should_skip(X, y):
+                    if y is not None:
+                        return X, y
+                    return X
+                if y is not None:
+                    y = self._cast_y_to_series(X, y)
+                if self._compound_prec(X, y):
+                    if verbose:
+                        msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
+                        print(msg, flush=True)
+                    if self._is_fittable():
+                        if self.is_fitted:
+                            if self._is_an_Xy_transformer:
+                                res_X, res_y = self._transform_Xy(
+                                    X, y, verbose=verbose
+                                )
+                            else:
+                                res_X = self._transform(X, verbose=verbose)
+                                res_y = y
+                            if exraise and not self._compound_post(
+                                X=res_X, y=res_y
+                            ):
+                                self._raise_postcondition_error()
+                            if y is not None:
+                                res_X, res_y = self._align_Xy(
+                                    X=res_X, y=res_y, preX=X
+                                )
+                                return res_X, res_y
+                            return res_X
+                        err_msg = (
+                            "transform of an unfitted pipeline stage was "
+                            "called!"
+                        )
+                        raise UnfittedPipelineStageError(err_msg)
+                    if self._is_an_Xy_transformer:
+                        res_X, res_y = self._transform_Xy(
+                            X, y, verbose=verbose
+                        )
+                    else:
+                        res_X = self._transform(X, verbose=verbose)
+                        res_y = y
+                    if exraise and not self._compound_post(X=res_X, y=res_y):
+                        self._raise_postcondition_error()
+                    if y is not None:
+                        res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
+                        return res_X, res_y
+                    return res_X
+                if exraise:
+                    self._raise_precondition_error()
+                # precondition doesn't hold, but we don't want to raise
+                # an error
+                # as exraise is False, so return untransformed X or X, y
                 if y is not None:
                     return X, y
                 return X
-            if y is not None:
-                y = self._cast_y_to_series(X, y)
-            if self._compound_prec(X, y):
-                if verbose:
-                    msg = "- " + "\n  ".join(textwrap.wrap(self._appmsg))
-                    print(msg, flush=True)
-                if self._is_fittable():
-                    if self.is_fitted:
-                        if self._is_an_Xy_transformer:
-                            res_X, res_y = self._transform_Xy(
-                                X, y, verbose=verbose
-                            )
-                        else:
-                            res_X = self._transform(X, verbose=verbose)
-                            res_y = y
-                        if exraise and not self._compound_post(
-                            X=res_X, y=res_y
-                        ):
-                            self._raise_postcondition_error()
-                        if y is not None:
-                            res_X, res_y = self._align_Xy(
-                                X=res_X, y=res_y, preX=X
-                            )
-                            return res_X, res_y
-                        return res_X
-                    raise UnfittedPipelineStageError(
-                        "transform of an unfitted pipeline stage was called!"
-                    )
-                if self._is_an_Xy_transformer:
-                    res_X, res_y = self._transform_Xy(X, y, verbose=verbose)
-                else:
-                    res_X = self._transform(X, verbose=verbose)
-                    res_y = y
-                if exraise and not self._compound_post(X=res_X, y=res_y):
-                    self._raise_postcondition_error()
-                if y is not None:
-                    res_X, res_y = self._align_Xy(X=res_X, y=res_y, preX=X)
-                    return res_X, res_y
-                return res_X
-            if exraise:
-                self._raise_precondition_error()
-            # precondition doesn't hold, but we don't want to raise an error
-            # as exraise is False, so return untransformed X or X, y
-            if y is not None:
-                return X, y
-            return X
 
     def __add__(self, other):
         if isinstance(other, PdPipeline):
@@ -1433,34 +1585,12 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
         self.fit_context.lock()
 
     @staticmethod
-    def _use_dynamics(
-        stage: PdPipelineStage,
-        inter_X: pd.DataFrame,
-        inter_y: Optional[pd.Series] = None,
-    ) -> None:
-        """Sets the dynamic parameter based on given callable.
-
-        Parameters
-        ----------
-        stage : pdpipe.PdPipelineStage
-            The stage for which to provide the dynamic parameter.
-        inter_X : pandas.DataFrame
-            The input dataframe.
-        inter_y : pandas.Series
-            The input y labels. Optional
-
-        Returns
-        -------
-        None
-
-        """
-        for dynamic in stage._dynamics:
-            param = (
-                dynamic["callable"](inter_X)
-                if inter_y is None
-                else dynamic["callable"](inter_X, inter_y)
-            )
-            setattr(stage, dynamic["name"], param)
+    def _stage_application_error_message(index, stage, error):
+        msg = f"Exception raised in stage [ {index}] {stage}"
+        detail = str(error)
+        if detail:
+            msg = f"{msg}: {detail}"
+        return msg
 
     def apply(
         self,
@@ -1569,7 +1699,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         else:
             for i, stage in enumerate(self._stages):
@@ -1589,7 +1719,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         self.is_fitted = True
         print(
@@ -1670,8 +1800,6 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 try:
                     stage.fit_context = self.fit_context
                     stage.application_context = self.application_context
-                    self._use_dynamics(stage, inter_X, inter_y)
-
                     inter_X = stage.fit_transform(
                         X=inter_X,
                         y=None,
@@ -1682,15 +1810,13 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         else:
             for i, stage in enumerate(self._stages):
                 try:
                     stage.fit_context = self.fit_context
                     stage.application_context = self.application_context
-                    self._use_dynamics(stage, inter_X, inter_y)
-
                     inter_X, inter_y = stage.fit_transform(
                         X=inter_X,
                         y=inter_y,
@@ -1701,7 +1827,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         self._post_transform_lock()
         self.is_fitted = True
@@ -1800,7 +1926,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         else:
             for i, stage in enumerate(self._stages):
@@ -1820,7 +1946,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         self.is_fitted = True
         print(
@@ -1896,8 +2022,6 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 try:
                     stage.fit_context = self.fit_context
                     stage.application_context = self.application_context
-                    self._use_dynamics(stage, inter_X, inter_y)
-
                     inter_X = stage.transform(
                         X=inter_X,
                         y=None,
@@ -1908,15 +2032,13 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         else:
             for i, stage in enumerate(self._stages):
                 try:
                     stage.fit_context = self.fit_context
                     stage.application_context = self.application_context
-                    self._use_dynamics(stage, inter_X, inter_y)
-
                     inter_X, inter_y = stage.transform(
                         X=inter_X,
                         y=inter_y,
@@ -1927,7 +2049,7 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
                 except Exception as e:
                     stage.application_context = None
                     raise PipelineApplicationError(
-                        f"Exception raised in stage [ {i}] {stage}"
+                        self._stage_application_error_message(i, stage, e)
                     ) from e
         self._post_transform_lock()
         if y is None:
@@ -2160,20 +2282,20 @@ class PdPipeline(PdPipelineStage, collections.abc.Sequence):
             stage.application_context = traced_pipeline.application_context
 
             try:
-                traced_pipeline._use_dynamics(stage, inter_X, inter_y)
-                (
-                    status,
-                    skip_reason,
-                    inter_X,
-                    inter_y,
-                ) = self._trace_apply_stage(
-                    stage=stage,
-                    X=inter_X,
-                    y=inter_y,
-                    fit=fit,
-                    exraise=exraise,
-                    verbose=verbose,
-                )
+                with stage._use_runtime_parameters(inter_X, inter_y):
+                    (
+                        status,
+                        skip_reason,
+                        inter_X,
+                        inter_y,
+                    ) = self._trace_apply_stage(
+                        stage=stage,
+                        X=inter_X,
+                        y=inter_y,
+                        fit=fit,
+                        exraise=exraise,
+                        verbose=verbose,
+                    )
                 trace_entry["status"] = status
                 trace_entry["skip_reason"] = skip_reason
                 self._trace_set_output(trace_entry, inter_X)

--- a/src/pdpipe/run_time_parameters.py
+++ b/src/pdpipe/run_time_parameters.py
@@ -115,3 +115,57 @@ def dynamic(
 
     """
     return DynamicParameter(parameter_selector, fittable)
+
+
+class ContextualParameter:
+    """A parameter whose value is read from a pipeline context at runtime.
+
+    Parameters
+    ----------
+    key : str
+        The context key whose value should be used.
+    fit : bool, default True
+        If True, read the value from the fit context. If False, read it from
+        the application context on each pipeline application.
+
+    """
+
+    def __init__(self, key: str, fit: bool = True) -> None:
+        if not isinstance(key, str):
+            raise TypeError("'key' must be a str")
+        if not isinstance(fit, bool):
+            raise TypeError("'fit' must be a bool")
+        self.key = key
+        self.fit = fit
+
+    def resolve(self, fit_context, application_context) -> object:
+        """Return this parameter's concrete value from pipeline context."""
+        context = fit_context if self.fit else application_context
+        context_name = "fit_context" if self.fit else "application_context"
+        try:
+            return context[self.key]
+        except (KeyError, TypeError) as e:
+            raise KeyError(
+                f"No value for contextual parameter {self.key!r} was found "
+                f"in {context_name}."
+            ) from e
+
+
+def contextual(key: str, fit: bool = True) -> ContextualParameter:
+    """Return a contextual parameter placeholder.
+
+    Parameters
+    ----------
+    key : str
+        The context key whose value should be used at runtime.
+    fit : bool, default True
+        If True, read the value from the fit context. If False, read it from
+        the application context on every pipeline application.
+
+    Returns
+    -------
+    ContextualParameter
+        A placeholder object resolved by pipeline stages at application time.
+
+    """
+    return ContextualParameter(key, fit)

--- a/tests/run_time_parameters/test_contextuals.py
+++ b/tests/run_time_parameters/test_contextuals.py
@@ -1,0 +1,359 @@
+"""Testing contextual runtime parameters."""
+
+import collections
+
+import pandas as pd
+import pytest
+
+import pdpipe as pdp
+from pdpipe.core import PdpApplicationContext
+from pdpipe.exceptions import PipelineApplicationError
+
+
+class PutFitContextStage(pdp.PdPipelineStage):
+    """A stage that stores a value in the fit context."""
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        super().__init__(desc="Put value in fit context")
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        self.fit_context[self.key] = self.value
+        return df
+
+
+class AddContextValueStage(pdp.PdPipelineStage):
+    """A stage that uses a contextual constructor parameter."""
+
+    def __init__(self, params, **kwargs):
+        self.params = params
+        super().__init__(desc="Add contextual value", **kwargs)
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        return df.assign(result=df["a"] + self.params["offset"])
+
+
+class AddContextValuesStage(pdp.PdPipelineStage):
+    """A stage that sums contextual values in a constructor parameter."""
+
+    def __init__(self, values):
+        self.values = values
+        super().__init__(desc="Add contextual values")
+
+    def _prec(self, df):
+        return True
+
+    def _transform(self, df, verbose):
+        return df.assign(result=df["a"] + sum(self.values))
+
+
+class FittableXyContextStage(pdp.PdPipelineStage):
+    """A fittable X/y stage that uses the fitted transform path."""
+
+    def __init__(self, offset):
+        self.offset = offset
+        super().__init__(desc="Fittable X/y contextual value")
+
+    def _prec(self, df, y=None):
+        return True
+
+    def _fit_transform(self, df, verbose):
+        return df
+
+    def _transform(self, df, verbose):
+        return df
+
+    def _transform_Xy(self, df, y, verbose):
+        return df.assign(result=df["a"] + self.offset), y + 1
+
+
+def _scale_df():
+    return pd.DataFrame([[2, 3], [5, 6]], columns=["a", "b"])
+
+
+def test_contextual_from_application_context_in_scale():
+    scale_stage = pdp.Scale(
+        scaler=pdp.contextual("scaling_type", fit=False),
+        joint=True,
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(
+                scaling_type=lambda df: "StandardScaler"
+            ),
+            scale_stage,
+        ]
+    )
+
+    res = pipeline.apply(_scale_df())
+    expected = pd.DataFrame(
+        [[-1.264911, -0.632456], [0.632456, 1.264911]],
+        columns=["a", "b"],
+    )
+
+    pd.testing.assert_frame_equal(res, expected)
+    assert isinstance(
+        scale_stage.scaler, pdp.run_time_parameters.ContextualParameter
+    )
+
+
+def test_contextual_from_fit_context_by_default_and_nested_restore():
+    add_stage = AddContextValueStage({"offset": pdp.contextual("fit_offset")})
+    pipeline = pdp.PdPipeline(
+        [
+            PutFitContextStage("fit_offset", 10),
+            add_stage,
+        ]
+    )
+    df = pd.DataFrame({"a": [1, 2]})
+
+    res = pipeline.apply(df)
+
+    expected = pd.DataFrame({"a": [1, 2], "result": [11, 12]})
+    pd.testing.assert_frame_equal(res, expected)
+    assert isinstance(
+        add_stage.params["offset"], pdp.run_time_parameters.ContextualParameter
+    )
+
+
+def test_contextual_from_fit_context_resolves_on_later_transform():
+    add_stage = AddContextValueStage({"offset": pdp.contextual("fit_offset")})
+    pipeline = pdp.PdPipeline(
+        [
+            PutFitContextStage("fit_offset", 10),
+            add_stage,
+        ]
+    )
+
+    pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+    res = pipeline.transform(pd.DataFrame({"a": [5, 7]}))
+
+    expected = pd.DataFrame({"a": [5, 7], "result": [15, 17]})
+    pd.testing.assert_frame_equal(res, expected)
+
+
+def test_contextual_application_context_resolves_on_each_transform():
+    add_stage = AddContextValueStage(
+        {"offset": pdp.contextual("app_offset", fit=False)}
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(
+                app_offset=lambda df: df["a"].max()
+            ),
+            add_stage,
+        ]
+    )
+
+    first = pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+    second = pipeline.apply(pd.DataFrame({"a": [5, 7]}))
+
+    pd.testing.assert_frame_equal(
+        first, pd.DataFrame({"a": [1, 2], "result": [3, 4]})
+    )
+    pd.testing.assert_frame_equal(
+        second, pd.DataFrame({"a": [5, 7], "result": [12, 14]})
+    )
+    assert isinstance(
+        add_stage.params["offset"], pdp.run_time_parameters.ContextualParameter
+    )
+
+
+def test_contextual_application_context_resolves_on_timed_transform():
+    add_stage = AddContextValueStage(
+        {"offset": pdp.contextual("app_offset", fit=False)}
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(
+                app_offset=lambda df: df["a"].max()
+            ),
+            add_stage,
+        ]
+    )
+
+    pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+    res = pipeline.transform(pd.DataFrame({"a": [5, 7]}), time=True)
+
+    pd.testing.assert_frame_equal(
+        res, pd.DataFrame({"a": [5, 7], "result": [12, 14]})
+    )
+
+
+def test_contextual_resolves_when_stage_is_applied_directly():
+    add_stage = AddContextValueStage({"offset": pdp.contextual("fit_offset")})
+    add_stage.fit_context = PdpApplicationContext()
+    add_stage.fit_context.update({"fit_offset": 4})
+
+    res = add_stage.apply(pd.DataFrame({"a": [1, 2]}))
+
+    expected = pd.DataFrame({"a": [1, 2], "result": [5, 6]})
+    pd.testing.assert_frame_equal(res, expected)
+
+
+def test_contextual_runtime_transform_skip_returns_unmodified_frame():
+    add_stage = AddContextValueStage(
+        {"offset": 1},
+        skip=lambda df: True,
+    )
+    df = pd.DataFrame({"a": [1, 2]})
+
+    res = add_stage.transform(df)
+
+    pd.testing.assert_frame_equal(res, df)
+
+
+def test_contextual_runtime_transform_fitted_xy_stage():
+    stage = FittableXyContextStage(3)
+    df = pd.DataFrame({"a": [1, 2]})
+    y = pd.Series([10, 20])
+    stage.fit(df, y=y)
+
+    res_X, res_y = stage.transform(df, y=y)
+
+    expected_X = pd.DataFrame({"a": [1, 2], "result": [4, 5]})
+    expected_y = pd.Series([11, 21])
+    pd.testing.assert_frame_equal(res_X, expected_X)
+    pd.testing.assert_series_equal(res_y, expected_y)
+
+
+def test_pipeline_error_message_omits_empty_error_detail():
+    stage = AddContextValueStage({"offset": 1})
+    msg = pdp.PdPipeline._stage_application_error_message(
+        0,
+        stage,
+        Exception(),
+    )
+
+    assert msg == f"Exception raised in stage [ 0] {stage}"
+
+
+def test_contextuals_support_mapping_attributes():
+    params = collections.UserDict({"offset": pdp.contextual("fit_offset")})
+    add_stage = AddContextValueStage(params)
+    pipeline = pdp.PdPipeline(
+        [
+            PutFitContextStage("fit_offset", 8),
+            add_stage,
+        ]
+    )
+
+    res = pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+
+    expected = pd.DataFrame({"a": [1, 2], "result": [9, 10]})
+    pd.testing.assert_frame_equal(res, expected)
+
+
+@pytest.mark.parametrize(
+    "container_factory",
+    [
+        list,
+        tuple,
+        set,
+    ],
+)
+def test_contextuals_support_sequence_attributes(container_factory):
+    values = container_factory([pdp.contextual("fit_offset"), 2])
+    add_stage = AddContextValuesStage(values)
+    pipeline = pdp.PdPipeline(
+        [
+            PutFitContextStage("fit_offset", 8),
+            add_stage,
+        ]
+    )
+
+    res = pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+
+    expected = pd.DataFrame({"a": [1, 2], "result": [11, 12]})
+    pd.testing.assert_frame_equal(res, expected)
+    assert isinstance(add_stage.values, container_factory)
+
+
+def test_contextuals_work_in_stage_kwargs():
+    scale_stage = pdp.Scale(
+        scaler="StandardScaler",
+        with_mean=pdp.contextual("with_mean", fit=False),
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(with_mean=lambda df: False),
+            scale_stage,
+        ]
+    )
+
+    res = pipeline.apply(pd.DataFrame({"a": [2, 5]}))
+
+    expected = pd.DataFrame({"a": [1.333333, 3.333333]})
+    pd.testing.assert_frame_equal(res, expected)
+    assert isinstance(
+        scale_stage._kwargs["with_mean"],
+        pdp.run_time_parameters.ContextualParameter,
+    )
+
+
+def test_contextual_missing_key_raises_pipeline_error():
+    pipeline = pdp.PdPipeline(
+        [
+            AddContextValueStage(
+                {"offset": pdp.contextual("missing", fit=False)}
+            )
+        ]
+    )
+
+    with pytest.raises(
+        PipelineApplicationError,
+        match="missing.*application_context",
+    ):
+        pipeline.apply(pd.DataFrame({"a": [1, 2]}))
+
+
+def test_contextual_rejects_non_bool_fit_flag():
+    with pytest.raises(TypeError, match="'fit' must be a bool"):
+        pdp.contextual("offset", fit=None)
+
+
+def test_contextual_rejects_non_string_key():
+    with pytest.raises(TypeError, match="'key' must be a str"):
+        pdp.contextual(1)
+
+
+def test_contextuals_work_in_timed_pipeline_path():
+    add_stage = AddContextValueStage(
+        {"offset": pdp.contextual("app_offset", fit=False)}
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(app_offset=lambda df: 5),
+            add_stage,
+        ]
+    )
+
+    res = pipeline.apply(pd.DataFrame({"a": [1, 2]}), time=True)
+
+    expected = pd.DataFrame({"a": [1, 2], "result": [6, 7]})
+    pd.testing.assert_frame_equal(res, expected)
+
+
+def test_contextuals_work_in_trace_path():
+    add_stage = AddContextValueStage(
+        {"offset": pdp.contextual("app_offset", fit=False)}
+    )
+    pipeline = pdp.PdPipeline(
+        [
+            pdp.ApplicationContextEnricher(app_offset=lambda df: 3),
+            add_stage,
+        ]
+    )
+
+    trace = pipeline.trace(pd.DataFrame({"a": [1, 2]}))
+
+    assert trace[-1]["status"] == "applied"
+    assert trace[-1]["output_columns"] == ["a", "result"]
+    assert trace[-1]["output_shape"] == (2, 2)

--- a/tests/run_time_parameters/test_dynamics.py
+++ b/tests/run_time_parameters/test_dynamics.py
@@ -91,6 +91,20 @@ def test_scaler_no_y():
     pd.testing.assert_frame_equal(res, expected_res)
 
 
+def test_scaler_no_y_timed_path():
+    scaler = _get_scaler(_scaling_decider_no_y)
+    pipeline = pdp.PdPipeline(stages=[scaler])
+
+    res = pipeline.apply(_standard_scaler_df(), time=True)
+
+    expected_res = pd.DataFrame(
+        [[-1.264911, -0.632456], [0.632456, 1.264911]],
+        columns=["a", "b"],
+    )
+    assert scaler.scaler == "StandardScaler"
+    pd.testing.assert_frame_equal(res, expected_res)
+
+
 def test_non_callable():
     with pytest.raises(PipelineApplicationError):
         scaler = _get_scaler("non_callable")


### PR DESCRIPTION
## Summary

Closes #105.

Adds `pdp.contextual(...)`, a runtime parameter placeholder that lets stage constructor attributes resolve from pipeline context while the stage is being applied. Contextual parameters default to the retained fit context and can use `fit=False` to resolve from the per-application context.

## Implementation

- Add `ContextualParameter` and the public `pdp.contextual` factory, with explicit validation that `fit` is a boolean.
- Resolve stage-owned contextual placeholders through `PdPipelineStage.fit_transform()` and `PdPipelineStage.transform()`, so direct stage use and every pipeline execution path share the same behavior.
- Support placeholders as direct constructor attributes or inside simple container attributes, including mappings, lists, tuples, and sets.
- Resolve contextual values only for the duration of a stage application, then restore the original placeholder templates in a `finally` block.
- Route the same runtime-parameter wrapper through normal fit, timed fit, normal transform, timed transform, and `trace()`.
- Preserve existing `pdp.dynamic` behavior while also applying dynamic parameters in the timed pipeline paths.
- Include the missing contextual key and relevant context name in wrapped pipeline errors.
- Keep the contextual resolver below Codacy's complexity threshold by splitting mapping and iterable resolution into focused helpers.
- Document contextual parameters and their read-only constructor-template semantics in the runtime-parameters tutorial.

## Validation

- `.venv/bin/python -m black .`
- `.venv/bin/python -m flake8 src tests`
- `.venv/bin/python -m pytest` (`504 passed`)
- `.venv/bin/mkdocs build -f mkdocs.yml`
- Local changed-line coverage check: no missing or partial changed lines in `src/pdpipe/core.py` or `src/pdpipe/run_time_parameters.py`.

## Notes

The implementation deliberately avoids a global contextual registry or process-wide enable flag. Resolution is scoped to each stage and application, which keeps `fit=False` contextual values re-resolvable on later transforms and prevents permanent hot-swapping of stage attributes.
